### PR TITLE
Slice 3: apply for a single repo (write managed values; never delete)

### DIFF
--- a/cmd/ghsecretman/main.go
+++ b/cmd/ghsecretman/main.go
@@ -32,6 +32,8 @@ func run(args []string, ver string, stdout, stderr io.Writer) int {
 		switch args[1] {
 		case "audit":
 			return runAudit(args[2:], stdout, stderr)
+		case "apply":
+			return runApply(args[2:], stdout, stderr)
 		}
 	}
 
@@ -46,7 +48,7 @@ func run(args []string, ver string, stdout, stderr io.Writer) int {
 		return 0
 	}
 
-	fmt.Fprintln(stderr, "usage: ghsecretman audit --config <path> --org <name> --repo <name>")
+	fmt.Fprintln(stderr, "usage: ghsecretman <audit|apply> --config <path> --org <name> --repo <name>")
 	return 2
 }
 
@@ -83,6 +85,43 @@ func runAudit(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	if res.Drift {
+		return 1
+	}
+	return 0
+}
+
+func runApply(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("apply", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	cfgPath := fs.String("config", "", "path to YAML config file")
+	org := fs.String("org", "", "GitHub organization name")
+	repo := fs.String("repo", "", "single repo to apply")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if *cfgPath == "" || *org == "" || *repo == "" {
+		fmt.Fprintln(stderr, "apply: --config, --org, and --repo are required")
+		return 2
+	}
+
+	cfg, err := config.Load(*cfgPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "load config: %v\n", err)
+		return 2
+	}
+
+	backend, err := backendFactory()
+	if err != nil {
+		fmt.Fprintf(stderr, "github: %v\n", err)
+		return 2
+	}
+
+	res, err := runner.ApplyRepo(context.Background(), cfg, *org, *repo, backend, stdout)
+	if err != nil {
+		fmt.Fprintf(stderr, "apply: %v\n", err)
+		return 1
+	}
+	if res.Failed > 0 {
 		return 1
 	}
 	return 0

--- a/cmd/ghsecretman/main_test.go
+++ b/cmd/ghsecretman/main_test.go
@@ -238,3 +238,134 @@ func TestRun_AuditBadFlag(t *testing.T) {
 		t.Fatalf("exit: got %d want 2", code)
 	}
 }
+
+func TestRun_ApplySuccess(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeCfg(t, dir, `
+github.com:
+  example:
+    per-repo:
+      acme:
+        managed:
+          vars:
+            V:
+              value: ok
+          secrets:
+            S:
+              value: secret
+          dependabot:
+            D:
+              value: dep
+`)
+	be := &fakeBackend{}
+	swapBackend(t, be, nil)
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"ghsecretman", "apply", "--config", cfgPath, "--org", "example", "--repo", "acme"}, "dev", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit: got %d want 0; stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if len(be.setVars) != 1 || be.setVars[0] != "V" {
+		t.Errorf("setVars: %v", be.setVars)
+	}
+	if len(be.setSecrets) != 1 || be.setSecrets[0] != "S" {
+		t.Errorf("setSecrets: %v", be.setSecrets)
+	}
+	if len(be.setDependabot) != 1 || be.setDependabot[0] != "D" {
+		t.Errorf("setDependabot: %v", be.setDependabot)
+	}
+	if !strings.Contains(stdout.String(), "vars/V: ok") {
+		t.Errorf("stdout missing per-entry ok line: %q", stdout.String())
+	}
+}
+
+func TestRun_ApplyMissingFlags(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"ghsecretman", "apply"}, "dev", &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("exit: got %d want 2", code)
+	}
+	if !strings.Contains(stderr.String(), "required") {
+		t.Fatalf("stderr should mention required: %q", stderr.String())
+	}
+}
+
+func TestRun_ApplyBadConfig(t *testing.T) {
+	swapBackend(t, &fakeBackend{}, nil)
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"ghsecretman", "apply", "--config", "/no/such/file.yml", "--org", "example", "--repo", "acme"}, "dev", &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("exit: got %d want 2", code)
+	}
+}
+
+func TestRun_ApplyBackendError(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeCfg(t, dir, `
+github.com:
+  example:
+    per-repo:
+      acme:
+        managed: {}
+`)
+	swapBackend(t, nil, errors.New("no token"))
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"ghsecretman", "apply", "--config", cfgPath, "--org", "example", "--repo", "acme"}, "dev", &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("exit: got %d want 2", code)
+	}
+}
+
+func TestRun_ApplyBadFlag(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"ghsecretman", "apply", "--bogus"}, "dev", &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("exit: got %d want 2", code)
+	}
+}
+
+func TestRun_ApplyUnknownRepo(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeCfg(t, dir, `
+github.com:
+  example:
+    per-repo: {}
+`)
+	swapBackend(t, &fakeBackend{}, nil)
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"ghsecretman", "apply", "--config", cfgPath, "--org", "example", "--repo", "nope"}, "dev", &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit: got %d want 1", code)
+	}
+}
+
+type failVarBackend struct {
+	fakeBackend
+}
+
+func (f *failVarBackend) SetRepoVariable(_ context.Context, _, _, _, _ string) error {
+	return errors.New("rate limit")
+}
+
+func TestRun_ApplyEntryFailureReturnsOne(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeCfg(t, dir, `
+github.com:
+  example:
+    per-repo:
+      acme:
+        managed:
+          vars:
+            V:
+              value: ok
+`)
+	swapBackend(t, &failVarBackend{}, nil)
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"ghsecretman", "apply", "--config", cfgPath, "--org", "example", "--repo", "acme"}, "dev", &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit: got %d want 1; stdout=%q", code, stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "vars/V: FAILED") {
+		t.Errorf("stdout missing FAILED line: %q", stdout.String())
+	}
+}

--- a/cmd/ghsecretman/main_test.go
+++ b/cmd/ghsecretman/main_test.go
@@ -74,6 +74,10 @@ type fakeBackend struct {
 	vars       map[string]string
 	secrets    []string
 	dependabot []string
+
+	setVars       []string
+	setSecrets    []string
+	setDependabot []string
 }
 
 func (f *fakeBackend) ListRepoVariables(_ context.Context, _, _ string) (map[string]string, error) {
@@ -84,6 +88,29 @@ func (f *fakeBackend) ListRepoSecrets(_ context.Context, _, _ string) ([]string,
 }
 func (f *fakeBackend) ListRepoDependabotSecrets(_ context.Context, _, _ string) ([]string, error) {
 	return f.dependabot, nil
+}
+
+func (f *fakeBackend) GetRepoPublicKey(_ context.Context, _, _ string) (*gh.PublicKey, error) {
+	return &gh.PublicKey{KeyID: "kid", Key: "AAAA"}, nil
+}
+
+func (f *fakeBackend) GetRepoDependabotPublicKey(_ context.Context, _, _ string) (*gh.PublicKey, error) {
+	return &gh.PublicKey{KeyID: "kid-dep", Key: "BBBB"}, nil
+}
+
+func (f *fakeBackend) SetRepoVariable(_ context.Context, _, _, name, _ string) error {
+	f.setVars = append(f.setVars, name)
+	return nil
+}
+
+func (f *fakeBackend) SetRepoSecret(_ context.Context, _, _, name string, _ *gh.PublicKey, _ string) error {
+	f.setSecrets = append(f.setSecrets, name)
+	return nil
+}
+
+func (f *fakeBackend) SetRepoDependabotSecret(_ context.Context, _, _, name string, _ *gh.PublicKey, _ string) error {
+	f.setDependabot = append(f.setDependabot, name)
+	return nil
 }
 
 func writeCfg(t *testing.T, dir, body string) string {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,11 @@ go 1.26.0
 
 require (
 	github.com/google/go-github/v85 v85.0.0
+	golang.org/x/crypto v0.50.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-require github.com/google/go-querystring v1.2.0 // indirect
+require (
+	github.com/google/go-querystring v1.2.0 // indirect
+	golang.org/x/sys v0.43.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,10 @@ github.com/google/go-github/v85 v85.0.0 h1:1+TLFX/akTFXK7o9Z9uAloQGufOn4ySa5DItU
 github.com/google/go-github/v85 v85.0.0/go.mod h1:jYkBnqN+SzR2A2fGKYfbt6DEEQAyxeK0Q2XpPV9ZFsU=
 github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=
 github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJZD5A0egEOmkqU=
+golang.org/x/crypto v0.50.0 h1:zO47/JPrL6vsNkINmLoo/PH1gcxpls50DNogFvB5ZGI=
+golang.org/x/crypto v0.50.0/go.mod h1:3muZ7vA7PBCE6xgPX7nkzzjiUq87kRItoJQM1Yo8S+Q=
+golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
+golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/github/encrypt.go
+++ b/internal/github/encrypt.go
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2026 Weston Schmidt <weston_schmidt@alumni.purdue.edu>
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+
+	"golang.org/x/crypto/nacl/box"
+)
+
+// PublicKey is a GitHub-issued libsodium public key used to encrypt secrets.
+type PublicKey struct {
+	KeyID string
+	Key   string // base64-encoded 32-byte recipient public key
+}
+
+// sealAnonymous wraps plaintext for the given base64-encoded 32-byte recipient
+// public key using libsodium's "sealed box" construction. The result is the
+// base64 of (ephemeral pub || ciphertext) — the format GitHub expects.
+func sealAnonymous(plaintext, recipientPubKeyB64 string) (string, error) {
+	pkBytes, err := base64.StdEncoding.DecodeString(recipientPubKeyB64)
+	if err != nil {
+		return "", fmt.Errorf("decode public key: %w", err)
+	}
+	if len(pkBytes) != 32 {
+		return "", fmt.Errorf("public key must be 32 bytes, got %d", len(pkBytes))
+	}
+	var pk [32]byte
+	copy(pk[:], pkBytes)
+	sealed, err := box.SealAnonymous(nil, []byte(plaintext), &pk, rand.Reader)
+	if err != nil {
+		return "", fmt.Errorf("seal anonymous: %w", err)
+	}
+	return base64.StdEncoding.EncodeToString(sealed), nil
+}

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -21,6 +21,13 @@ type Backend interface {
 	ListRepoVariables(ctx context.Context, owner, repo string) (map[string]string, error)
 	ListRepoSecrets(ctx context.Context, owner, repo string) ([]string, error)
 	ListRepoDependabotSecrets(ctx context.Context, owner, repo string) ([]string, error)
+
+	GetRepoPublicKey(ctx context.Context, owner, repo string) (*PublicKey, error)
+	GetRepoDependabotPublicKey(ctx context.Context, owner, repo string) (*PublicKey, error)
+
+	SetRepoVariable(ctx context.Context, owner, repo, name, value string) error
+	SetRepoSecret(ctx context.Context, owner, repo, name string, key *PublicKey, plaintext string) error
+	SetRepoDependabotSecret(ctx context.Context, owner, repo, name string, key *PublicKey, plaintext string) error
 }
 
 // Client is the live GitHub backend.
@@ -79,6 +86,87 @@ func (c *Client) ListRepoDependabotSecrets(ctx context.Context, owner, repo stri
 		return nil, fmt.Errorf("list repo dependabot secrets: %w", err)
 	}
 	return namesOf(secrets), nil
+}
+
+// GetRepoPublicKey fetches the public key used to encrypt repo Actions secrets.
+func (c *Client) GetRepoPublicKey(ctx context.Context, owner, repo string) (*PublicKey, error) {
+	pk, _, err := c.gh.Actions.GetRepoPublicKey(ctx, owner, repo)
+	if err != nil {
+		return nil, fmt.Errorf("get repo actions public key: %w", err)
+	}
+	return toPublicKey(pk)
+}
+
+// GetRepoDependabotPublicKey fetches the public key used to encrypt repo
+// Dependabot secrets.
+func (c *Client) GetRepoDependabotPublicKey(ctx context.Context, owner, repo string) (*PublicKey, error) {
+	pk, _, err := c.gh.Dependabot.GetRepoPublicKey(ctx, owner, repo)
+	if err != nil {
+		return nil, fmt.Errorf("get repo dependabot public key: %w", err)
+	}
+	return toPublicKey(pk)
+}
+
+// SetRepoVariable creates or updates a repo Actions variable.
+//
+// The GitHub API exposes create (POST) and update (PATCH) as separate
+// endpoints. We try update first; on 404 we fall back to create. This
+// keeps the Backend surface "set, don't ask".
+func (c *Client) SetRepoVariable(ctx context.Context, owner, repo, name, value string) error {
+	v := &gogithub.ActionsVariable{Name: name, Value: value}
+	resp, err := c.gh.Actions.UpdateRepoVariable(ctx, owner, repo, v)
+	if err == nil {
+		return nil
+	}
+	if resp != nil && resp.StatusCode == 404 {
+		if _, cerr := c.gh.Actions.CreateRepoVariable(ctx, owner, repo, v); cerr != nil {
+			return fmt.Errorf("create repo variable %s: %w", name, cerr)
+		}
+		return nil
+	}
+	return fmt.Errorf("update repo variable %s: %w", name, err)
+}
+
+// SetRepoSecret creates or updates a repo Actions secret. plaintext is
+// encrypted client-side with libsodium sealed-box against key before being
+// sent to GitHub.
+func (c *Client) SetRepoSecret(ctx context.Context, owner, repo, name string, key *PublicKey, plaintext string) error {
+	if key == nil {
+		return fmt.Errorf("set repo secret %s: missing public key", name)
+	}
+	enc, err := sealAnonymous(plaintext, key.Key)
+	if err != nil {
+		return fmt.Errorf("encrypt repo secret %s: %w", name, err)
+	}
+	es := &gogithub.EncryptedSecret{Name: name, KeyID: key.KeyID, EncryptedValue: enc}
+	if _, err := c.gh.Actions.CreateOrUpdateRepoSecret(ctx, owner, repo, es); err != nil {
+		return fmt.Errorf("set repo secret %s: %w", name, err)
+	}
+	return nil
+}
+
+// SetRepoDependabotSecret creates or updates a repo Dependabot secret using
+// the Dependabot-specific public key.
+func (c *Client) SetRepoDependabotSecret(ctx context.Context, owner, repo, name string, key *PublicKey, plaintext string) error {
+	if key == nil {
+		return fmt.Errorf("set repo dependabot secret %s: missing public key", name)
+	}
+	enc, err := sealAnonymous(plaintext, key.Key)
+	if err != nil {
+		return fmt.Errorf("encrypt repo dependabot secret %s: %w", name, err)
+	}
+	es := &gogithub.DependabotEncryptedSecret{Name: name, KeyID: key.KeyID, EncryptedValue: enc}
+	if _, err := c.gh.Dependabot.CreateOrUpdateRepoSecret(ctx, owner, repo, es); err != nil {
+		return fmt.Errorf("set repo dependabot secret %s: %w", name, err)
+	}
+	return nil
+}
+
+func toPublicKey(pk *gogithub.PublicKey) (*PublicKey, error) {
+	if pk == nil || pk.KeyID == nil || pk.Key == nil {
+		return nil, errors.New("github returned an empty public key")
+	}
+	return &PublicKey{KeyID: *pk.KeyID, Key: *pk.Key}, nil
 }
 
 func namesOf(s *gogithub.Secrets) []string {

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -122,7 +122,7 @@ func TestNewClientFromEnv_NoToken(t *testing.T) {
 func TestClient_GetRepoPublicKey(t *testing.T) {
 	t.Parallel()
 	srv, c := newTestClient(t, map[string]string{
-		"/repos/example/acme/actions/secrets/public-key": `{"key_id":"kid-actions","key":"AAAA"}`,
+		"/repos/example/acme/actions/secrets/public-key": `{"key_id":"kid-actions","key":"AAAA"}`, // #nosec G101 -- fixture, no credentials
 	})
 	defer srv.Close()
 
@@ -138,7 +138,7 @@ func TestClient_GetRepoPublicKey(t *testing.T) {
 func TestClient_GetRepoDependabotPublicKey(t *testing.T) {
 	t.Parallel()
 	srv, c := newTestClient(t, map[string]string{
-		"/repos/example/acme/dependabot/secrets/public-key": `{"key_id":"kid-dep","key":"BBBB"}`,
+		"/repos/example/acme/dependabot/secrets/public-key": `{"key_id":"kid-dep","key":"BBBB"}`, // #nosec G101 -- fixture, no credentials
 	})
 	defer srv.Close()
 

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -5,15 +5,21 @@ package github
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 
 	gogithub "github.com/google/go-github/v85/github"
+	"golang.org/x/crypto/nacl/box"
 )
 
 func TestClient_ListRepoVariables(t *testing.T) {
@@ -111,6 +117,342 @@ func TestNewClientFromEnv_NoToken(t *testing.T) {
 	if _, err := NewClientFromEnv(); err == nil {
 		t.Fatal("expected error when no token set")
 	}
+}
+
+func TestClient_GetRepoPublicKey(t *testing.T) {
+	t.Parallel()
+	srv, c := newTestClient(t, map[string]string{
+		"/repos/example/acme/actions/secrets/public-key": `{"key_id":"kid-actions","key":"AAAA"}`,
+	})
+	defer srv.Close()
+
+	pk, err := c.GetRepoPublicKey(context.Background(), "example", "acme")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pk.KeyID != "kid-actions" || pk.Key != "AAAA" {
+		t.Fatalf("got %+v", pk)
+	}
+}
+
+func TestClient_GetRepoDependabotPublicKey(t *testing.T) {
+	t.Parallel()
+	srv, c := newTestClient(t, map[string]string{
+		"/repos/example/acme/dependabot/secrets/public-key": `{"key_id":"kid-dep","key":"BBBB"}`,
+	})
+	defer srv.Close()
+
+	pk, err := c.GetRepoDependabotPublicKey(context.Background(), "example", "acme")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pk.KeyID != "kid-dep" || pk.Key != "BBBB" {
+		t.Fatalf("got %+v", pk)
+	}
+}
+
+func TestClient_GetRepoPublicKey_Error(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"nope"}`, http.StatusForbidden)
+	}))
+	defer srv.Close()
+	c := newClientPointingAt(t, srv.URL)
+	if _, err := c.GetRepoPublicKey(context.Background(), "example", "acme"); err == nil {
+		t.Fatal("expected error")
+	}
+	if _, err := c.GetRepoDependabotPublicKey(context.Background(), "example", "acme"); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestClient_SetRepoVariable_Update(t *testing.T) {
+	t.Parallel()
+	var got struct {
+		method string
+		path   string
+		body   map[string]any
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got.method = r.Method
+		got.path = r.URL.Path
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &got.body)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+	c := newClientPointingAt(t, srv.URL)
+
+	if err := c.SetRepoVariable(context.Background(), "example", "acme", "V", "ok"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.method != http.MethodPatch {
+		t.Errorf("method: got %s want PATCH", got.method)
+	}
+	if got.path != "/repos/example/acme/actions/variables/V" {
+		t.Errorf("path: %s", got.path)
+	}
+	if got.body["name"] != "V" || got.body["value"] != "ok" {
+		t.Errorf("body: %+v", got.body)
+	}
+}
+
+func TestClient_SetRepoVariable_CreateFallback(t *testing.T) {
+	t.Parallel()
+	var (
+		mu    sync.Mutex
+		calls []string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		calls = append(calls, r.Method+" "+r.URL.Path)
+		if r.Method == http.MethodPatch {
+			http.Error(w, `{"message":"not found"}`, http.StatusNotFound)
+			return
+		}
+		// POST creates
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+	c := newClientPointingAt(t, srv.URL)
+
+	if err := c.SetRepoVariable(context.Background(), "example", "acme", "V", "ok"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{
+		"PATCH /repos/example/acme/actions/variables/V",
+		"POST /repos/example/acme/actions/variables",
+	}
+	if strings.Join(calls, "|") != strings.Join(want, "|") {
+		t.Fatalf("calls: %v want %v", calls, want)
+	}
+}
+
+func TestClient_SetRepoVariable_UpdateError(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"server"}`, http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	c := newClientPointingAt(t, srv.URL)
+	if err := c.SetRepoVariable(context.Background(), "example", "acme", "V", "ok"); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestClient_SetRepoVariable_CreateError(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPatch {
+			http.Error(w, `{"message":"not found"}`, http.StatusNotFound)
+			return
+		}
+		http.Error(w, `{"message":"boom"}`, http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	c := newClientPointingAt(t, srv.URL)
+	if err := c.SetRepoVariable(context.Background(), "example", "acme", "V", "ok"); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestClient_SetRepoSecret_EncryptsAndPuts(t *testing.T) {
+	t.Parallel()
+	pub, priv := genBoxKeypair(t)
+	pubB64 := base64.StdEncoding.EncodeToString(pub[:])
+
+	var captured struct {
+		method, path string
+		body         map[string]any
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.method = r.Method
+		captured.path = r.URL.Path
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &captured.body)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+	c := newClientPointingAt(t, srv.URL)
+
+	err := c.SetRepoSecret(context.Background(), "example", "acme", "S",
+		&PublicKey{KeyID: "kid", Key: pubB64}, "plain-text-value")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if captured.method != http.MethodPut {
+		t.Errorf("method: %s", captured.method)
+	}
+	if captured.path != "/repos/example/acme/actions/secrets/S" {
+		t.Errorf("path: %s", captured.path)
+	}
+	if captured.body["key_id"] != "kid" {
+		t.Errorf("key_id: %v", captured.body["key_id"])
+	}
+	encB64, _ := captured.body["encrypted_value"].(string)
+	if encB64 == "" {
+		t.Fatalf("encrypted_value missing in body: %+v", captured.body)
+	}
+	plain := decryptSealedBox(t, encB64, pub, priv)
+	if plain != "plain-text-value" {
+		t.Errorf("decrypted: got %q want %q", plain, "plain-text-value")
+	}
+}
+
+func TestClient_SetRepoSecret_NilKey(t *testing.T) {
+	t.Parallel()
+	c := newClientPointingAt(t, "http://127.0.0.1:0")
+	if err := c.SetRepoSecret(context.Background(), "example", "acme", "S", nil, "v"); err == nil {
+		t.Fatal("expected error for nil key")
+	}
+}
+
+func TestClient_SetRepoSecret_BadKey(t *testing.T) {
+	t.Parallel()
+	c := newClientPointingAt(t, "http://127.0.0.1:0")
+	err := c.SetRepoSecret(context.Background(), "example", "acme", "S",
+		&PublicKey{KeyID: "kid", Key: "not-base64!!!"}, "v")
+	if err == nil {
+		t.Fatal("expected error for bad public key")
+	}
+}
+
+func TestClient_SetRepoSecret_APIError(t *testing.T) {
+	t.Parallel()
+	pub, _ := genBoxKeypair(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"nope"}`, http.StatusForbidden)
+	}))
+	defer srv.Close()
+	c := newClientPointingAt(t, srv.URL)
+	err := c.SetRepoSecret(context.Background(), "example", "acme", "S",
+		&PublicKey{KeyID: "kid", Key: base64.StdEncoding.EncodeToString(pub[:])}, "v")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestClient_SetRepoDependabotSecret_EncryptsAndPuts(t *testing.T) {
+	t.Parallel()
+	pub, priv := genBoxKeypair(t)
+	pubB64 := base64.StdEncoding.EncodeToString(pub[:])
+
+	var captured struct {
+		method, path string
+		body         map[string]any
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.method = r.Method
+		captured.path = r.URL.Path
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &captured.body)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+	c := newClientPointingAt(t, srv.URL)
+
+	err := c.SetRepoDependabotSecret(context.Background(), "example", "acme", "D",
+		&PublicKey{KeyID: "kid-dep", Key: pubB64}, "dep-secret")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if captured.method != http.MethodPut {
+		t.Errorf("method: %s", captured.method)
+	}
+	if captured.path != "/repos/example/acme/dependabot/secrets/D" {
+		t.Errorf("path: %s", captured.path)
+	}
+	if captured.body["key_id"] != "kid-dep" {
+		t.Errorf("key_id: %v", captured.body["key_id"])
+	}
+	encB64, _ := captured.body["encrypted_value"].(string)
+	if encB64 == "" {
+		t.Fatalf("encrypted_value missing: %+v", captured.body)
+	}
+	plain := decryptSealedBox(t, encB64, pub, priv)
+	if plain != "dep-secret" {
+		t.Errorf("decrypted: got %q", plain)
+	}
+}
+
+func TestClient_SetRepoDependabotSecret_NilKey(t *testing.T) {
+	t.Parallel()
+	c := newClientPointingAt(t, "http://127.0.0.1:0")
+	if err := c.SetRepoDependabotSecret(context.Background(), "example", "acme", "D", nil, "v"); err == nil {
+		t.Fatal("expected error for nil key")
+	}
+}
+
+func TestClient_SetRepoDependabotSecret_BadKey(t *testing.T) {
+	t.Parallel()
+	c := newClientPointingAt(t, "http://127.0.0.1:0")
+	err := c.SetRepoDependabotSecret(context.Background(), "example", "acme", "D",
+		&PublicKey{KeyID: "kid", Key: "not-base64!!!"}, "v")
+	if err == nil {
+		t.Fatal("expected error for bad public key")
+	}
+}
+
+func TestClient_SetRepoDependabotSecret_APIError(t *testing.T) {
+	t.Parallel()
+	pub, _ := genBoxKeypair(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"nope"}`, http.StatusForbidden)
+	}))
+	defer srv.Close()
+	c := newClientPointingAt(t, srv.URL)
+	err := c.SetRepoDependabotSecret(context.Background(), "example", "acme", "D",
+		&PublicKey{KeyID: "kid", Key: base64.StdEncoding.EncodeToString(pub[:])}, "v")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestSealAnonymous_Roundtrip(t *testing.T) {
+	t.Parallel()
+	pub, priv := genBoxKeypair(t)
+	encB64, err := sealAnonymous("hello world", base64.StdEncoding.EncodeToString(pub[:]))
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	plain := decryptSealedBox(t, encB64, pub, priv)
+	if plain != "hello world" {
+		t.Errorf("decrypt: %q", plain)
+	}
+}
+
+func TestSealAnonymous_BadKey(t *testing.T) {
+	t.Parallel()
+	if _, err := sealAnonymous("x", "not-base64!!"); err == nil {
+		t.Error("expected error for bad base64")
+	}
+	short := base64.StdEncoding.EncodeToString([]byte("short"))
+	if _, err := sealAnonymous("x", short); err == nil {
+		t.Error("expected error for wrong key length")
+	}
+}
+
+func genBoxKeypair(t *testing.T) (*[32]byte, *[32]byte) {
+	t.Helper()
+	pub, priv, err := box.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pub, priv
+}
+
+func decryptSealedBox(t *testing.T, encB64 string, pub, priv *[32]byte) string {
+	t.Helper()
+	enc, err := base64.StdEncoding.DecodeString(encB64)
+	if err != nil {
+		t.Fatalf("decode encrypted: %v", err)
+	}
+	out, ok := box.OpenAnonymous(nil, enc, pub, priv)
+	if !ok {
+		t.Fatalf("OpenAnonymous failed")
+	}
+	return string(out)
 }
 
 func newTestClient(t *testing.T, responses map[string]string) (*httptest.Server, *Client) {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -19,9 +19,13 @@ import (
 	"github.com/schmidtw/ghsecretman/internal/resolve"
 )
 
-// Result reports the outcome of a single-repo audit.
+// Result reports the outcome of a single-repo run.
+//
+// Drift is set by AuditRepo. Failed counts per-entry write failures during
+// ApplyRepo (and could be repurposed for enforce later).
 type Result struct {
-	Drift bool
+	Drift  bool
+	Failed int
 }
 
 // AuditRepo runs an audit against a single repo and writes a labeled
@@ -98,6 +102,103 @@ func writeStanza(out io.Writer, org, repo string, entries []diff.Entry, showIgno
 			fmt.Fprintf(out, "  %s/%s: %s\n", e.Kind, e.Name, e.Status)
 		}
 	}
+}
+
+// ApplyRepo writes managed values for a single repo. It never deletes and
+// never touches anything outside the repo's `managed` block. A per-entry
+// "ok" or "FAILED: <err>" line is written for each managed entry; a final
+// summary line is written if any entry failed.
+//
+// The repo's Actions and Dependabot public keys are fetched at most once
+// per call (only when the corresponding section has at least one entry)
+// and reused across all set calls.
+func ApplyRepo(ctx context.Context, cfg *config.Config, org, repo string, backend gh.Backend, out io.Writer) (Result, error) {
+	o, ok := cfg.Org(org)
+	if !ok {
+		return Result{}, fmt.Errorf("org %q not found in config", org)
+	}
+	r, ok := o.PerRepo[repo]
+	if !ok {
+		return Result{}, fmt.Errorf("repo %q not found under org %q", repo, org)
+	}
+
+	intents := plan.ForRepo(repo, r)
+	resolved, err := resolveAll(intents)
+	if err != nil {
+		return Result{}, err
+	}
+
+	actionsKey, depKey, err := fetchKeys(ctx, backend, org, repo, intents)
+	if err != nil {
+		return Result{}, err
+	}
+
+	fmt.Fprintf(out, "org: %s\nrepo: %s\n", org, repo)
+	res := Result{}
+	for _, in := range intents {
+		err := applyOne(ctx, backend, org, repo, in, resolved[entryKey(in)], actionsKey, depKey)
+		if err != nil {
+			res.Failed++
+			fmt.Fprintf(out, "  %s/%s: FAILED: %v\n", in.Kind, in.Name, err)
+			continue
+		}
+		fmt.Fprintf(out, "  %s/%s: ok\n", in.Kind, in.Name)
+	}
+	if res.Failed > 0 {
+		fmt.Fprintf(out, "summary: %d failed\n", res.Failed)
+	}
+	return res, nil
+}
+
+func applyOne(ctx context.Context, backend gh.Backend, org, repo string, in plan.Intent, value string, actionsKey, depKey *gh.PublicKey) error {
+	switch in.Kind {
+	case plan.KindVar:
+		return backend.SetRepoVariable(ctx, org, repo, in.Name, value)
+	case plan.KindSecret:
+		return backend.SetRepoSecret(ctx, org, repo, in.Name, actionsKey, value)
+	case plan.KindDependabot:
+		return backend.SetRepoDependabotSecret(ctx, org, repo, in.Name, depKey, value)
+	}
+	return fmt.Errorf("unknown kind %q", in.Kind)
+}
+
+func resolveAll(intents []plan.Intent) (map[string]string, error) {
+	out := map[string]string{}
+	for _, in := range intents {
+		v, err := resolve.Resolve(in.Entry)
+		if err != nil {
+			return nil, fmt.Errorf("resolve %s/%s: %w", in.Kind, in.Name, err)
+		}
+		out[entryKey(in)] = v
+	}
+	return out, nil
+}
+
+func entryKey(in plan.Intent) string { return string(in.Kind) + "/" + in.Name }
+
+func fetchKeys(ctx context.Context, backend gh.Backend, org, repo string, intents []plan.Intent) (actions, dependabot *gh.PublicKey, err error) {
+	needsActions, needsDep := false, false
+	for _, in := range intents {
+		switch in.Kind {
+		case plan.KindSecret:
+			needsActions = true
+		case plan.KindDependabot:
+			needsDep = true
+		}
+	}
+	if needsActions {
+		actions, err = backend.GetRepoPublicKey(ctx, org, repo)
+		if err != nil {
+			return nil, nil, fmt.Errorf("fetch actions public key: %w", err)
+		}
+	}
+	if needsDep {
+		dependabot, err = backend.GetRepoDependabotPublicKey(ctx, org, repo)
+		if err != nil {
+			return nil, nil, fmt.Errorf("fetch dependabot public key: %w", err)
+		}
+	}
+	return actions, dependabot, nil
 }
 
 // writeFile is a thin wrapper used by tests to materialize fixture YAML.

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -24,6 +25,9 @@ type fakeBackend struct {
 
 	actionsKey    *gh.PublicKey
 	dependabotKey *gh.PublicKey
+
+	actionsKeyErr    error
+	dependabotKeyErr error
 
 	mu          sync.Mutex
 	setVarCalls []setVarCall
@@ -64,6 +68,9 @@ func (f *fakeBackend) GetRepoPublicKey(_ context.Context, _, _ string) (*gh.Publ
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.actionsKeyFetches++
+	if f.actionsKeyErr != nil {
+		return nil, f.actionsKeyErr
+	}
 	if f.actionsKey == nil {
 		return &gh.PublicKey{KeyID: "key-actions", Key: "AAAA"}, nil
 	}
@@ -74,6 +81,9 @@ func (f *fakeBackend) GetRepoDependabotPublicKey(_ context.Context, _, _ string)
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.dependabotKeyFetches++
+	if f.dependabotKeyErr != nil {
+		return nil, f.dependabotKeyErr
+	}
 	if f.dependabotKey == nil {
 		return &gh.PublicKey{KeyID: "key-dep", Key: "BBBB"}, nil
 	}
@@ -312,6 +322,308 @@ github.com:
 	if err == nil {
 		t.Fatal("expected error for missing file")
 	}
+}
+
+func TestApplyRepo_WritesAllSections(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := writeFile(filepath.Join(dir, "f.txt"), []byte("file-val")); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(dir, "secrets.yml")
+	if err := writeFile(cfgPath, []byte(`
+github.com:
+  example:
+    per-repo:
+      acme:
+        managed:
+          vars:
+            V1:
+              value: v-one
+            V2:
+              file: f.txt
+          secrets:
+            S1:
+              value: s-one
+            S2:
+              value: s-two
+          dependabot:
+            D1:
+              value: d-one
+        ignored:
+          vars:
+            - IG_VAR
+`)); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	be := &fakeBackend{}
+	var out bytes.Buffer
+	res, err := ApplyRepo(context.Background(), cfg, "example", "acme", be, &out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Failed != 0 {
+		t.Errorf("expected zero failures, got %d", res.Failed)
+	}
+
+	if got := callNames(be.setVarCalls); !equalSorted(got, []string{"V1", "V2"}) {
+		t.Errorf("vars set: got %v want [V1 V2]", got)
+	}
+	if got := secretCallNames(be.setSecCalls); !equalSorted(got, []string{"S1", "S2"}) {
+		t.Errorf("secrets set: got %v want [S1 S2]", got)
+	}
+	if got := secretCallNames(be.setDepCalls); !equalSorted(got, []string{"D1"}) {
+		t.Errorf("dependabot set: got %v want [D1]", got)
+	}
+
+	for _, c := range be.setVarCalls {
+		switch c.name {
+		case "V1":
+			if c.value != "v-one" {
+				t.Errorf("V1 value: %q", c.value)
+			}
+		case "V2":
+			if c.value != "file-val" {
+				t.Errorf("V2 value: %q", c.value)
+			}
+		}
+	}
+	for _, c := range be.setSecCalls {
+		if c.keyID != "key-actions" {
+			t.Errorf("secret %s: keyID=%q", c.name, c.keyID)
+		}
+	}
+	for _, c := range be.setDepCalls {
+		if c.keyID != "key-dep" {
+			t.Errorf("dependabot %s: keyID=%q", c.name, c.keyID)
+		}
+	}
+
+	if be.actionsKeyFetches != 1 {
+		t.Errorf("actions key fetched %d times; expected exactly 1", be.actionsKeyFetches)
+	}
+	if be.dependabotKeyFetches != 1 {
+		t.Errorf("dependabot key fetched %d times; expected exactly 1", be.dependabotKeyFetches)
+	}
+
+	s := out.String()
+	for _, want := range []string{"repo: acme", "vars/V1: ok", "secrets/S1: ok", "dependabot/D1: ok"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("output missing %q\n--\n%s", want, s)
+		}
+	}
+	if strings.Contains(s, "FAILED") {
+		t.Errorf("unexpected FAILED line:\n%s", s)
+	}
+	if strings.Contains(s, "summary:") {
+		t.Errorf("no summary line should appear when nothing failed:\n%s", s)
+	}
+}
+
+func TestApplyRepo_OnlyVars_NoKeyFetch(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "secrets.yml")
+	if err := writeFile(cfgPath, []byte(`
+github.com:
+  example:
+    per-repo:
+      acme:
+        managed:
+          vars:
+            V:
+              value: x
+`)); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	be := &fakeBackend{}
+	if _, err := ApplyRepo(context.Background(), cfg, "example", "acme", be, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	if be.actionsKeyFetches != 0 || be.dependabotKeyFetches != 0 {
+		t.Errorf("no key should be fetched when only vars are managed; actions=%d dep=%d",
+			be.actionsKeyFetches, be.dependabotKeyFetches)
+	}
+}
+
+func TestApplyRepo_PerEntryFailureContinues(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "secrets.yml")
+	if err := writeFile(cfgPath, []byte(`
+github.com:
+  example:
+    per-repo:
+      acme:
+        managed:
+          vars:
+            V_GOOD:
+              value: ok
+            V_BAD:
+              value: ok
+          secrets:
+            S_GOOD:
+              value: ok
+`)); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	be := &fakeBackend{
+		setErr: map[string]error{"vars/V_BAD": errors.New("rate limit")},
+	}
+	var out bytes.Buffer
+	res, err := ApplyRepo(context.Background(), cfg, "example", "acme", be, &out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Failed != 1 {
+		t.Errorf("expected 1 failure, got %d", res.Failed)
+	}
+	if got := callNames(be.setVarCalls); !equalSorted(got, []string{"V_GOOD"}) {
+		t.Errorf("V_BAD should not appear in successful var calls: %v", got)
+	}
+	if len(be.setSecCalls) != 1 {
+		t.Errorf("S_GOOD should still be applied after V_BAD failed: %+v", be.setSecCalls)
+	}
+	s := out.String()
+	if !strings.Contains(s, "vars/V_BAD: FAILED: rate limit") {
+		t.Errorf("output missing failure line:\n%s", s)
+	}
+	if !strings.Contains(s, "summary: 1 failed") {
+		t.Errorf("output missing summary line:\n%s", s)
+	}
+}
+
+func TestApplyRepo_KeyFetchFailure(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "secrets.yml")
+	if err := writeFile(cfgPath, []byte(`
+github.com:
+  example:
+    per-repo:
+      acme:
+        managed:
+          secrets:
+            S:
+              value: x
+`)); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	be := &fakeBackend{actionsKeyErr: errors.New("forbidden")}
+	if _, err := ApplyRepo(context.Background(), cfg, "example", "acme", be, &bytes.Buffer{}); err == nil {
+		t.Fatal("expected error when public key fetch fails")
+	}
+}
+
+func TestApplyRepo_DependabotKeyFetchFailure(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "secrets.yml")
+	if err := writeFile(cfgPath, []byte(`
+github.com:
+  example:
+    per-repo:
+      acme:
+        managed:
+          dependabot:
+            D:
+              value: x
+`)); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	be := &fakeBackend{dependabotKeyErr: errors.New("forbidden")}
+	if _, err := ApplyRepo(context.Background(), cfg, "example", "acme", be, &bytes.Buffer{}); err == nil {
+		t.Fatal("expected error when dependabot public key fetch fails")
+	}
+}
+
+func TestApplyRepo_ResolveError(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "secrets.yml")
+	if err := writeFile(cfgPath, []byte(`
+github.com:
+  example:
+    per-repo:
+      acme:
+        managed:
+          vars:
+            V:
+              file: missing.txt
+`)); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ApplyRepo(context.Background(), cfg, "example", "acme", &fakeBackend{}, &bytes.Buffer{}); err == nil {
+		t.Fatal("expected resolve error")
+	}
+}
+
+func TestApplyRepo_UnknownOrgRepo(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{Orgs: map[string]*config.Org{}}
+	if _, err := ApplyRepo(context.Background(), cfg, "missing", "acme", &fakeBackend{}, &bytes.Buffer{}); err == nil {
+		t.Fatal("expected error for unknown org")
+	}
+	cfg.Orgs["example"] = &config.Org{PerRepo: map[string]*config.Repo{}}
+	if _, err := ApplyRepo(context.Background(), cfg, "example", "missing", &fakeBackend{}, &bytes.Buffer{}); err == nil {
+		t.Fatal("expected error for unknown repo")
+	}
+}
+
+func callNames(cs []setVarCall) []string {
+	out := make([]string, 0, len(cs))
+	for _, c := range cs {
+		out = append(out, c.name)
+	}
+	return out
+}
+
+func secretCallNames(cs []setSecretCall) []string {
+	out := make([]string, 0, len(cs))
+	for _, c := range cs {
+		out = append(out, c.name)
+	}
+	return out
+}
+
+func equalSorted(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	aa := append([]string(nil), a...)
+	bb := append([]string(nil), b...)
+	slices.Sort(aa)
+	slices.Sort(bb)
+	for i := range aa {
+		if aa[i] != bb[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func TestAuditRepo_ShowIgnored(t *testing.T) {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -9,9 +9,11 @@ import (
 	"errors"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/schmidtw/ghsecretman/internal/config"
+	gh "github.com/schmidtw/ghsecretman/internal/github"
 )
 
 type fakeBackend struct {
@@ -19,6 +21,30 @@ type fakeBackend struct {
 	secrets    []string
 	dependabot []string
 	err        error
+
+	actionsKey    *gh.PublicKey
+	dependabotKey *gh.PublicKey
+
+	mu          sync.Mutex
+	setVarCalls []setVarCall
+	setSecCalls []setSecretCall
+	setDepCalls []setSecretCall
+
+	// keyFetchCount tracks how many times each key fetch endpoint was called.
+	actionsKeyFetches    int
+	dependabotKeyFetches int
+
+	// setErr injects errors for specific (kind, name) pairs.
+	setErr map[string]error
+}
+
+type setVarCall struct {
+	owner, repo, name, value string
+}
+
+type setSecretCall struct {
+	owner, repo, name, plaintext string
+	keyID                        string
 }
 
 func (f *fakeBackend) ListRepoVariables(_ context.Context, _, _ string) (map[string]string, error) {
@@ -32,6 +58,64 @@ func (f *fakeBackend) ListRepoSecrets(_ context.Context, _, _ string) ([]string,
 }
 func (f *fakeBackend) ListRepoDependabotSecrets(_ context.Context, _, _ string) ([]string, error) {
 	return f.dependabot, f.err
+}
+
+func (f *fakeBackend) GetRepoPublicKey(_ context.Context, _, _ string) (*gh.PublicKey, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.actionsKeyFetches++
+	if f.actionsKey == nil {
+		return &gh.PublicKey{KeyID: "key-actions", Key: "AAAA"}, nil
+	}
+	return f.actionsKey, nil
+}
+
+func (f *fakeBackend) GetRepoDependabotPublicKey(_ context.Context, _, _ string) (*gh.PublicKey, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.dependabotKeyFetches++
+	if f.dependabotKey == nil {
+		return &gh.PublicKey{KeyID: "key-dep", Key: "BBBB"}, nil
+	}
+	return f.dependabotKey, nil
+}
+
+func (f *fakeBackend) SetRepoVariable(_ context.Context, owner, repo, name, value string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if e, ok := f.setErr["vars/"+name]; ok {
+		return e
+	}
+	f.setVarCalls = append(f.setVarCalls, setVarCall{owner, repo, name, value})
+	return nil
+}
+
+func (f *fakeBackend) SetRepoSecret(_ context.Context, owner, repo, name string, key *gh.PublicKey, plaintext string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if e, ok := f.setErr["secrets/"+name]; ok {
+		return e
+	}
+	keyID := ""
+	if key != nil {
+		keyID = key.KeyID
+	}
+	f.setSecCalls = append(f.setSecCalls, setSecretCall{owner, repo, name, plaintext, keyID})
+	return nil
+}
+
+func (f *fakeBackend) SetRepoDependabotSecret(_ context.Context, owner, repo, name string, key *gh.PublicKey, plaintext string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if e, ok := f.setErr["dependabot/"+name]; ok {
+		return e
+	}
+	keyID := ""
+	if key != nil {
+		keyID = key.KeyID
+	}
+	f.setDepCalls = append(f.setDepCalls, setSecretCall{owner, repo, name, plaintext, keyID})
+	return nil
 }
 
 func TestAuditRepo_Drift(t *testing.T) {


### PR DESCRIPTION
Fixes #4

## Summary

- `internal/github` gains `GetRepoPublicKey`, `GetRepoDependabotPublicKey`, `SetRepoVariable`, `SetRepoSecret`, and `SetRepoDependabotSecret`. Secrets are encrypted client-side with libsodium sealed-box (`golang.org/x/crypto/nacl/box`) and sent in the standard `{key_id, encrypted_value}` envelope. Variable writes try `PATCH` first, falling back to `POST` on 404.
- `internal/runner` gains `ApplyRepo`, which resolves every managed entry, fetches each public key at most once per call (only when its section has entries), dispatches to the backend, prints `vars/X: ok` or `vars/X: FAILED: <err>` per entry, and surfaces a `Failed` count for exit-code policy. Failures do not abort the run.
- `cmd/ghsecretman` wires the `apply` subcommand with the same `--config / --org / --repo` flags as `audit` and exits non-zero on any per-entry write failure.

## Test plan

- [x] `go test ./...` — all packages pass
- [x] `go test ./... -cover` — every package ≥ 89% (cli 95.5, config 89.0, diff 100, github 93.5, plan 90.9, resolve 100, runner 96.8)
- [x] `golangci-lint run` — 0 issues
- [x] `github` httptest tests verify request shape and decrypt the captured body to prove the sealed-box envelope round-trips
- [x] `runner` fake-backend tests verify each kind dispatches correctly, that public keys are fetched exactly once when needed and not at all when no secrets are managed, and that a per-entry failure does not stop subsequent entries
- [x] `cli` smoke tests cover success, missing flags, bad config, backend init failure, unknown repo, bogus flag, and per-entry failure exit code