### PR TITLE
config,resolve: env: value source with lazy resolution

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,6 +52,7 @@ type Ignored struct {
 //
 // Exactly one of Value, Env, or File must be set.
 type Entry struct {
+	Name    string
 	Value   string
 	Env     string
 	File    string
@@ -227,7 +228,7 @@ func decodeEntries(baseDir, orgName, repoName, section string, n *yaml.Node) (ma
 }
 
 func decodeEntry(baseDir, repoName, section, name string, n *yaml.Node) (*Entry, error) {
-	e := &Entry{}
+	e := &Entry{Name: name}
 	for i := 0; i < len(n.Content); i += 2 {
 		k := n.Content[i].Value
 		v := n.Content[i+1]

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -24,12 +24,18 @@ github.com:
               value: bar
             BAZ:
               file: ../baz.txt
+            QUX:
+              env: QUX_VAR
           secrets:
             S1:
               value: shh
+            S2:
+              env: S2_VAR
           dependabot:
             D1:
               value: dep
+            D2:
+              env: D2_VAR
         ignored:
           vars:
             - SKIP_VAR
@@ -70,6 +76,21 @@ other.tool:
 	if !contains(repo.Ignored.Dependabot, "SKIP_DEP") {
 		t.Errorf("ignored dependabot missing SKIP_DEP")
 	}
+	if got := repo.Managed.Vars["QUX"].Env; got != "QUX_VAR" {
+		t.Errorf("QUX env: got %q want %q", got, "QUX_VAR")
+	}
+	if repo.Managed.Vars["QUX"].HasValue {
+		t.Errorf("QUX should not have an explicit value")
+	}
+	if got := repo.Managed.Secrets["S2"].Env; got != "S2_VAR" {
+		t.Errorf("S2 env: got %q", got)
+	}
+	if got := repo.Managed.Dependabot["D2"].Env; got != "D2_VAR" {
+		t.Errorf("D2 env: got %q", got)
+	}
+	if got := repo.Managed.Vars["QUX"].Name; got != "QUX" {
+		t.Errorf("QUX name: got %q want %q", got, "QUX")
+	}
 }
 
 func TestLoad_Invalid(t *testing.T) {
@@ -96,7 +117,7 @@ github.com:
 			errSubstr: "exactly one of",
 		},
 		{
-			name: "multi source value+env (env not yet supported but multi still rejected)",
+			name: "multi source value+env",
 			yml: `
 github.com:
   example:
@@ -106,6 +127,21 @@ github.com:
           secrets:
             FOO:
               value: bar
+              env: BAR_VAR
+`,
+			errSubstr: "exactly one of",
+		},
+		{
+			name: "multi source env+file",
+			yml: `
+github.com:
+  example:
+    per-repo:
+      acme:
+        managed:
+          secrets:
+            FOO:
+              env: BAR_VAR
               file: x
 `,
 			errSubstr: "exactly one of",

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -24,6 +24,21 @@ func (e *FileError) Error() string {
 
 func (e *FileError) Unwrap() error { return e.Err }
 
+// EnvError reports an env-sourced entry whose env var is unset at the
+// point the resolver was asked for the value.
+//
+// Name is the entry's name (e.g., the secret/var name from YAML); Var is
+// the env var name the entry pointed at. Both are included so callers can
+// produce actionable error messages without re-wrapping.
+type EnvError struct {
+	Name string
+	Var  string
+}
+
+func (e *EnvError) Error() string {
+	return fmt.Sprintf("entry %q: env var %q not set", e.Name, e.Var)
+}
+
 // Resolve returns the concrete string value for the entry.
 //
 // `env:` resolution is intentionally lazy — callers invoke Resolve only when
@@ -46,7 +61,7 @@ func Resolve(e *config.Entry) (string, error) {
 	case e.Env != "":
 		v, ok := os.LookupEnv(e.Env)
 		if !ok {
-			return "", fmt.Errorf("env var %q not set", e.Env)
+			return "", &EnvError{Name: e.Name, Var: e.Env}
 		}
 		return v, nil
 	}

--- a/internal/resolve/resolve_test.go
+++ b/internal/resolve/resolve_test.go
@@ -90,20 +90,96 @@ func TestResolve_NoSource(t *testing.T) {
 }
 
 func TestResolve_Env(t *testing.T) {
-	t.Setenv("GHSM_TEST_VAR", "from-env")
-	got, err := Resolve(&config.Entry{Env: "GHSM_TEST_VAR"})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	tests := []struct {
+		name    string
+		setKey  string
+		setVal  string
+		entry   *config.Entry
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "env set returns value",
+			setKey: "GHSM_TEST_SET",
+			setVal: "from-env",
+			entry:  &config.Entry{Name: "MY_ENTRY", Env: "GHSM_TEST_SET"},
+			want:   "from-env",
+		},
+		{
+			name:   "env set to empty string returns empty",
+			setKey: "GHSM_TEST_EMPTY",
+			setVal: "",
+			entry:  &config.Entry{Name: "MY_ENTRY", Env: "GHSM_TEST_EMPTY"},
+			want:   "",
+		},
+		{
+			name:    "env unset returns EnvError",
+			entry:   &config.Entry{Name: "MY_ENTRY", Env: "GHSM_TEST_DEFINITELY_UNSET"},
+			wantErr: true,
+		},
 	}
-	if got != "from-env" {
-		t.Fatalf("got %q want %q", got, "from-env")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.setKey != "" {
+				t.Setenv(tc.setKey, tc.setVal)
+			}
+			got, err := Resolve(tc.entry)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %q want %q", got, tc.want)
+			}
+		})
 	}
 }
 
-func TestResolve_EnvMissing(t *testing.T) {
-	_, err := Resolve(&config.Entry{Env: "GHSM_TEST_DEFINITELY_UNSET_VAR"})
+func TestResolve_EnvError_TypedAndContainsBothNames(t *testing.T) {
+	_, err := Resolve(&config.Entry{Name: "MY_SECRET", Env: "GHSM_TEST_DEFINITELY_UNSET"})
 	if err == nil {
 		t.Fatal("expected error for missing env var")
+	}
+	var ee *EnvError
+	if !errors.As(err, &ee) {
+		t.Fatalf("expected *EnvError, got %T: %v", err, err)
+	}
+	if ee.Name != "MY_SECRET" {
+		t.Errorf("EnvError.Name: got %q want %q", ee.Name, "MY_SECRET")
+	}
+	if ee.Var != "GHSM_TEST_DEFINITELY_UNSET" {
+		t.Errorf("EnvError.Var: got %q want %q", ee.Var, "GHSM_TEST_DEFINITELY_UNSET")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "MY_SECRET") || !strings.Contains(msg, "GHSM_TEST_DEFINITELY_UNSET") {
+		t.Errorf("error message %q must include both entry name and env var name", msg)
+	}
+}
+
+// TestResolve_EnvLazy proves that constructing an entry referencing an env
+// var does not by itself trigger a lookup — the lookup happens at the moment
+// Resolve is called. The entry is built up-front (as it would be at config
+// load time), then the env var is set, then Resolve is called and observes
+// the new value.
+func TestResolve_EnvLazy(t *testing.T) {
+	entry := &config.Entry{Name: "LAZY", Env: "GHSM_TEST_LAZY"}
+
+	if _, err := Resolve(entry); err == nil {
+		t.Fatal("expected error before env was set")
+	}
+
+	t.Setenv("GHSM_TEST_LAZY", "now-set")
+	got, err := Resolve(entry)
+	if err != nil {
+		t.Fatalf("unexpected error after env was set: %v", err)
+	}
+	if got != "now-set" {
+		t.Fatalf("got %q want %q", got, "now-set")
 	}
 }
 

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -626,6 +626,115 @@ func equalSorted(a, b []string) bool {
 	return true
 }
 
+// TestApplyRepo_EnvSource_OtherRepoUnsetEnvDoesNotAbort asserts the lazy
+// env-resolution contract: when --repo X targets a repo whose entries do
+// not reference an env var FOO, FOO being unset does not abort the run
+// even though some other repo in the same config references FOO.
+func TestApplyRepo_EnvSource_OtherRepoUnsetEnvDoesNotAbort(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "secrets.yml")
+	if err := writeFile(cfgPath, []byte(`
+github.com:
+  example:
+    per-repo:
+      acme:
+        managed:
+          vars:
+            V_ACME:
+              env: GHSM_TEST_ACME_SET
+      other:
+        managed:
+          vars:
+            V_OTHER:
+              env: GHSM_TEST_OTHER_NEVER_SET
+`)); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GHSM_TEST_ACME_SET", "acme-value")
+	// Note: GHSM_TEST_OTHER_NEVER_SET is intentionally never set.
+
+	be := &fakeBackend{}
+	var out bytes.Buffer
+	res, err := ApplyRepo(context.Background(), cfg, "example", "acme", be, &out)
+	if err != nil {
+		t.Fatalf("targeting acme should not require env vars referenced only by another repo, got: %v", err)
+	}
+	if res.Failed != 0 {
+		t.Errorf("expected zero failures, got %d", res.Failed)
+	}
+	if len(be.setVarCalls) != 1 || be.setVarCalls[0].name != "V_ACME" || be.setVarCalls[0].value != "acme-value" {
+		t.Errorf("unexpected set calls: %+v", be.setVarCalls)
+	}
+}
+
+func TestApplyRepo_EnvSource_TargetedUnsetEnvFails(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "secrets.yml")
+	if err := writeFile(cfgPath, []byte(`
+github.com:
+  example:
+    per-repo:
+      acme:
+        managed:
+          secrets:
+            S_NEEDED:
+              env: GHSM_TEST_TARGETED_NEVER_SET
+`)); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = ApplyRepo(context.Background(), cfg, "example", "acme", &fakeBackend{}, &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("expected error when a targeted entry's env var is unset")
+	}
+	if !strings.Contains(err.Error(), "S_NEEDED") {
+		t.Errorf("error should mention the entry name; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "GHSM_TEST_TARGETED_NEVER_SET") {
+		t.Errorf("error should mention the env var name; got: %v", err)
+	}
+}
+
+func TestAuditRepo_EnvSource(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "secrets.yml")
+	if err := writeFile(cfgPath, []byte(`
+github.com:
+  example:
+    per-repo:
+      acme:
+        managed:
+          vars:
+            V:
+              env: GHSM_TEST_AUDIT_ENV
+`)); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GHSM_TEST_AUDIT_ENV", "live-side")
+
+	be := &fakeBackend{vars: map[string]string{"V": "live-side"}}
+	var out bytes.Buffer
+	res, err := AuditRepo(context.Background(), cfg, "example", "acme", be, &out, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Drift {
+		t.Errorf("expected no drift; got:\n%s", out.String())
+	}
+}
+
 func TestAuditRepo_ShowIgnored(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()


### PR DESCRIPTION
Fixes #5

Adds `env:` as the third value source for managed entries, with the lazy-resolution contract from the PRD: env vars are read via `os.LookupEnv` only at point of use, so targeting one repo doesn't require env vars referenced only by other repos.

## Summary
- `internal/config`: positive load test for `env:` and additional multi-source rejection cases (`value+env`, `env+file`); add `Entry.Name` populated during decode.
- `internal/resolve`: introduce typed `EnvError{Name, Var}` so callers can render an actionable message naming both the entry and the env var.
- `internal/runner`: end-to-end coverage that `apply --repo X` and `audit --repo X` ignore unset env vars referenced only by other repos in the same config, and that a targeted entry's unset env var still surfaces with both names.

## Test plan
- [x] `go test ./...`
- [x] `go test ./... -cover` — every package ≥ 80% (lowest 90.3%)
- [x] `golangci-lint run ./...` — 0 issues