### PR TITLE
Slice 5: per-repo ignored block (third truth-table state)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -155,7 +155,7 @@ func decodeRepo(baseDir, orgName, repoName string, n *yaml.Node) (*Repo, error) 
 		val := n.Content[i+1]
 		switch key {
 		case "managed":
-			m, err := decodeManaged(baseDir, orgName, repoName, val)
+			m, err := decodeManaged(baseDir, repoName, val)
 			if err != nil {
 				return nil, err
 			}
@@ -170,10 +170,34 @@ func decodeRepo(baseDir, orgName, repoName string, n *yaml.Node) (*Repo, error) 
 			return nil, fmt.Errorf("repo %q: unknown key %q", repoName, key)
 		}
 	}
+	if err := checkManagedIgnoredConflict(repoName, repo); err != nil {
+		return nil, err
+	}
 	return repo, nil
 }
 
-func decodeManaged(baseDir, orgName, repoName string, n *yaml.Node) (Managed, error) {
+func checkManagedIgnoredConflict(repoName string, r *Repo) error {
+	conflicts := []struct {
+		section string
+		managed map[string]*Entry
+		ignored []string
+	}{
+		{"vars", r.Managed.Vars, r.Ignored.Vars},
+		{"secrets", r.Managed.Secrets, r.Ignored.Secrets},
+		{"dependabot", r.Managed.Dependabot, r.Ignored.Dependabot},
+	}
+	for _, c := range conflicts {
+		for _, name := range c.ignored {
+			if _, ok := c.managed[name]; ok {
+				return fmt.Errorf("repo %q: %q appears in both managed.%s and ignored.%s",
+					repoName, name, c.section, c.section)
+			}
+		}
+	}
+	return nil
+}
+
+func decodeManaged(baseDir, repoName string, n *yaml.Node) (Managed, error) {
 	var m Managed
 	if n.Kind != yaml.MappingNode {
 		return m, fmt.Errorf("repo %q: managed must be a mapping", repoName)
@@ -183,19 +207,19 @@ func decodeManaged(baseDir, orgName, repoName string, n *yaml.Node) (Managed, er
 		val := n.Content[i+1]
 		switch key {
 		case "vars":
-			entries, err := decodeEntries(baseDir, orgName, repoName, "vars", val)
+			entries, err := decodeEntries(baseDir, repoName, "vars", val)
 			if err != nil {
 				return m, err
 			}
 			m.Vars = entries
 		case "secrets":
-			entries, err := decodeEntries(baseDir, orgName, repoName, "secrets", val)
+			entries, err := decodeEntries(baseDir, repoName, "secrets", val)
 			if err != nil {
 				return m, err
 			}
 			m.Secrets = entries
 		case "dependabot":
-			entries, err := decodeEntries(baseDir, orgName, repoName, "dependabot", val)
+			entries, err := decodeEntries(baseDir, repoName, "dependabot", val)
 			if err != nil {
 				return m, err
 			}
@@ -207,7 +231,7 @@ func decodeManaged(baseDir, orgName, repoName string, n *yaml.Node) (Managed, er
 	return m, nil
 }
 
-func decodeEntries(baseDir, orgName, repoName, section string, n *yaml.Node) (map[string]*Entry, error) {
+func decodeEntries(baseDir, repoName, section string, n *yaml.Node) (map[string]*Entry, error) {
 	if n.Kind != yaml.MappingNode {
 		return nil, fmt.Errorf("repo %q: managed.%s must be a mapping", repoName, section)
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -226,6 +226,70 @@ github.com:
 `,
 			errSubstr: "list of strings",
 		},
+		{
+			name: "managed and ignored conflict: vars",
+			yml: `
+github.com:
+  example:
+    per-repo:
+      acme:
+        managed:
+          vars:
+            DUP:
+              value: x
+        ignored:
+          vars:
+            - DUP
+`,
+			errSubstr: "DUP",
+		},
+		{
+			name: "managed and ignored conflict: secrets",
+			yml: `
+github.com:
+  example:
+    per-repo:
+      acme:
+        managed:
+          secrets:
+            DUP:
+              value: x
+        ignored:
+          secrets:
+            - DUP
+`,
+			errSubstr: "DUP",
+		},
+		{
+			name: "managed and ignored conflict: dependabot",
+			yml: `
+github.com:
+  example:
+    per-repo:
+      acme:
+        managed:
+          dependabot:
+            DUP:
+              value: x
+        ignored:
+          dependabot:
+            - DUP
+`,
+			errSubstr: "DUP",
+		},
+		{
+			name: "unknown key in ignored",
+			yml: `
+github.com:
+  example:
+    per-repo:
+      acme:
+        ignored:
+          bogus:
+            - X
+`,
+			errSubstr: "unknown",
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -64,7 +64,7 @@ func computeVars(repo string, intents []plan.Intent, desiredVars map[string]stri
 	out := make([]Entry, 0)
 	intentNames := make([]string, 0)
 	for _, in := range intents {
-		if in.Kind != plan.KindVar {
+		if in.Kind != plan.KindVar || in.Action != plan.ActionManaged {
 			continue
 		}
 		intended[in.Name] = struct{}{}
@@ -111,7 +111,7 @@ func computeNames(repo string, kind plan.Kind, intents []plan.Intent, liveNames 
 	out := make([]Entry, 0)
 	intentNames := make([]string, 0)
 	for _, in := range intents {
-		if in.Kind != kind {
+		if in.Kind != kind || in.Action != plan.ActionManaged {
 			continue
 		}
 		intended[in.Name] = struct{}{}

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -67,6 +67,38 @@ func TestCompute_SecretsAndDependabot(t *testing.T) {
 	checkEntries(t, got, want)
 }
 
+func TestCompute_SkipIntentsDoNotCountAsIntended(t *testing.T) {
+	t.Parallel()
+	// A skip-intent (Action=ActionIgnored) for IG_VAR must not make the
+	// diff treat IG_VAR as an intended write: the live IG_VAR should be
+	// reported as Ignored, not Match/Mismatch/Missing.
+	intents := []plan.Intent{
+		{Repo: "acme", Kind: plan.KindVar, Name: "IG_VAR", Action: plan.ActionIgnored},
+		{Repo: "acme", Kind: plan.KindSecret, Name: "IG_SEC", Action: plan.ActionIgnored},
+		{Repo: "acme", Kind: plan.KindDependabot, Name: "IG_DEP", Action: plan.ActionIgnored},
+	}
+	live := Live{
+		Vars:       map[string]string{"IG_VAR": "v"},
+		Secrets:    []string{"IG_SEC"},
+		Dependabot: []string{"IG_DEP"},
+	}
+	ig := config.Ignored{
+		Vars:       []string{"IG_VAR"},
+		Secrets:    []string{"IG_SEC"},
+		Dependabot: []string{"IG_DEP"},
+	}
+	got := Compute("acme", intents, nil, live, ig)
+	want := map[string]Status{
+		"vars/IG_VAR":       Ignored,
+		"secrets/IG_SEC":    Ignored,
+		"dependabot/IG_DEP": Ignored,
+	}
+	checkEntries(t, got, want)
+	if HasDrift(got) {
+		t.Errorf("ignored entries should not register as drift")
+	}
+}
+
 func TestCompute_IgnoredSuppressesExtra(t *testing.T) {
 	t.Parallel()
 	live := Live{

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -28,6 +28,9 @@ const (
 	// ActionManaged means the entry is in the managed block — apply/audit
 	// against it.
 	ActionManaged Action = "managed"
+	// ActionIgnored means the name appears in the ignored block at this
+	// scope — skip it for both apply and audit-output.
+	ActionIgnored Action = "ignored"
 )
 
 // Intent is one (target, kind, name) action with its source entry.
@@ -39,22 +42,23 @@ type Intent struct {
 	Entry  *config.Entry
 }
 
-// ForRepo returns intents for every managed entry on the repo.
+// ForRepo returns intents for every managed entry on the repo plus a
+// skip-intent for every name in the ignored block.
 //
 // Output order is stable: section order vars, secrets, dependabot;
-// names sorted within each section.
+// within each section, managed names sorted, then ignored names sorted.
 func ForRepo(repo string, r *config.Repo) []Intent {
 	if r == nil {
 		return nil
 	}
 	out := make([]Intent, 0)
-	out = appendKind(out, repo, KindVar, r.Managed.Vars)
-	out = appendKind(out, repo, KindSecret, r.Managed.Secrets)
-	out = appendKind(out, repo, KindDependabot, r.Managed.Dependabot)
+	out = appendKind(out, repo, KindVar, r.Managed.Vars, r.Ignored.Vars)
+	out = appendKind(out, repo, KindSecret, r.Managed.Secrets, r.Ignored.Secrets)
+	out = appendKind(out, repo, KindDependabot, r.Managed.Dependabot, r.Ignored.Dependabot)
 	return out
 }
 
-func appendKind(out []Intent, repo string, kind Kind, m map[string]*config.Entry) []Intent {
+func appendKind(out []Intent, repo string, kind Kind, m map[string]*config.Entry, ignored []string) []Intent {
 	names := make([]string, 0, len(m))
 	for n := range m {
 		names = append(names, n)
@@ -67,6 +71,16 @@ func appendKind(out []Intent, repo string, kind Kind, m map[string]*config.Entry
 			Name:   n,
 			Action: ActionManaged,
 			Entry:  m[n],
+		})
+	}
+	ig := append([]string(nil), ignored...)
+	sort.Strings(ig)
+	for _, n := range ig {
+		out = append(out, Intent{
+			Repo:   repo,
+			Kind:   kind,
+			Name:   n,
+			Action: ActionIgnored,
 		})
 	}
 	return out

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -36,12 +36,21 @@ func TestForRepo(t *testing.T) {
 	got := summarize(intents)
 	want := []string{
 		"acme/dependabot/D1/managed",
+		"acme/dependabot/IGD/ignored",
+		"acme/secrets/IGS/ignored",
 		"acme/secrets/S1/managed",
+		"acme/vars/IGV/ignored",
 		"acme/vars/V1/managed",
 		"acme/vars/V2/managed",
 	}
 	if !equal(got, want) {
 		t.Fatalf("intents:\ngot  %v\nwant %v", got, want)
+	}
+
+	for _, in := range intents {
+		if in.Action == ActionIgnored && in.Entry != nil {
+			t.Errorf("ignored intent should have nil Entry; got %+v", in)
+		}
 	}
 
 	if !IsIgnored(repo, KindVar, "IGV") {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -61,7 +61,7 @@ func AuditRepo(ctx context.Context, cfg *config.Config, org, repo string, backen
 func resolveVars(intents []plan.Intent) (map[string]string, error) {
 	out := map[string]string{}
 	for _, in := range intents {
-		if in.Kind != plan.KindVar {
+		if in.Kind != plan.KindVar || in.Action != plan.ActionManaged {
 			continue
 		}
 		v, err := resolve.Resolve(in.Entry)
@@ -136,6 +136,9 @@ func ApplyRepo(ctx context.Context, cfg *config.Config, org, repo string, backen
 	fmt.Fprintf(out, "org: %s\nrepo: %s\n", org, repo)
 	res := Result{}
 	for _, in := range intents {
+		if in.Action != plan.ActionManaged {
+			continue
+		}
 		err := applyOne(ctx, backend, org, repo, in, resolved[entryKey(in)], actionsKey, depKey)
 		if err != nil {
 			res.Failed++
@@ -165,6 +168,9 @@ func applyOne(ctx context.Context, backend gh.Backend, org, repo string, in plan
 func resolveAll(intents []plan.Intent) (map[string]string, error) {
 	out := map[string]string{}
 	for _, in := range intents {
+		if in.Action != plan.ActionManaged {
+			continue
+		}
 		v, err := resolve.Resolve(in.Entry)
 		if err != nil {
 			return nil, fmt.Errorf("resolve %s/%s: %w", in.Kind, in.Name, err)
@@ -179,6 +185,9 @@ func entryKey(in plan.Intent) string { return string(in.Kind) + "/" + in.Name }
 func fetchKeys(ctx context.Context, backend gh.Backend, org, repo string, intents []plan.Intent) (actions, dependabot *gh.PublicKey, err error) {
 	needsActions, needsDep := false, false
 	for _, in := range intents {
+		if in.Action != plan.ActionManaged {
+			continue
+		}
 		switch in.Kind {
 		case plan.KindSecret:
 			needsActions = true

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -735,6 +735,75 @@ github.com:
 	}
 }
 
+// TestApplyRepo_DoesNotWriteIgnored asserts that names listed in the
+// per-repo `ignored` block are never set, even when no managed entry of
+// the same name exists. The fake backend records every Set call, so any
+// write to an ignored name would show up here.
+func TestApplyRepo_DoesNotWriteIgnored(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "secrets.yml")
+	if err := writeFile(cfgPath, []byte(`
+github.com:
+  example:
+    per-repo:
+      acme:
+        managed:
+          vars:
+            V_ON:
+              value: ok
+          secrets:
+            S_ON:
+              value: ok
+          dependabot:
+            D_ON:
+              value: ok
+        ignored:
+          vars:
+            - V_OFF
+          secrets:
+            - S_OFF
+          dependabot:
+            - D_OFF
+`)); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	be := &fakeBackend{}
+	var out bytes.Buffer
+	res, err := ApplyRepo(context.Background(), cfg, "example", "acme", be, &out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Failed != 0 {
+		t.Errorf("expected zero failures, got %d", res.Failed)
+	}
+	for _, c := range be.setVarCalls {
+		if c.name == "V_OFF" {
+			t.Errorf("ignored var V_OFF must not be written; got %+v", c)
+		}
+	}
+	for _, c := range be.setSecCalls {
+		if c.name == "S_OFF" {
+			t.Errorf("ignored secret S_OFF must not be written; got %+v", c)
+		}
+	}
+	for _, c := range be.setDepCalls {
+		if c.name == "D_OFF" {
+			t.Errorf("ignored dependabot D_OFF must not be written; got %+v", c)
+		}
+	}
+	s := out.String()
+	for _, name := range []string{"V_OFF", "S_OFF", "D_OFF"} {
+		if strings.Contains(s, name) {
+			t.Errorf("apply output should not mention ignored name %q; got:\n%s", name, s)
+		}
+	}
+}
+
 func TestAuditRepo_ShowIgnored(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()


### PR DESCRIPTION
Fixes #6

Adds the third state to the per-repo audit/apply truth table.

- `internal/config`: rejects a name appearing in both `managed` and `ignored` at the same scope (vars, secrets, dependabot) with a clear error.
- `internal/plan`: `ForRepo` now emits `Action=ActionIgnored` skip-intents for every name in the per-repo `ignored` block, alongside the existing `ActionManaged` intents.
- `internal/diff`: `Compute` filters intents on `ActionManaged` so skip-intents do not pollute the intended-vs-extra computation; ignored names continue to be reported as `Ignored` (silent in default audit output, surfaced with `--show-ignored`).
- `internal/runner`: `ApplyRepo` (and its helpers `resolveAll`, `fetchKeys`, `resolveVars`) now skip non-managed intents, so ignored names are never written and do not trigger key fetches or env/file resolution.

Tests added:
- `config`: conflict rejection for each of vars/secrets/dependabot.
- `plan`: skip-intents emitted in the expected stable order, with nil `Entry`.
- `diff`: skip-intent stream produces `Ignored` (not Match/Missing) and does not register as drift.
- `runner`: `ApplyRepo` never calls Set on names listed in `ignored`.