### PR TITLE
Slice 6: enforce command (apply + delete unlisted; --dry-run; --yes)

### DIFF
--- a/cmd/ghsecretman/main.go
+++ b/cmd/ghsecretman/main.go
@@ -6,11 +6,13 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"flag"
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/schmidtw/ghsecretman/internal/config"
 	gh "github.com/schmidtw/ghsecretman/internal/github"
@@ -23,6 +25,19 @@ var version = "dev"
 // backendFactory is overridden in tests to inject a fake backend.
 var backendFactory = func() (gh.Backend, error) { return gh.NewClientFromEnv() }
 
+// isTTY reports whether stdin is connected to a terminal. It is a package
+// variable so tests can override the answer without manipulating fds.
+var isTTY = func() bool {
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return (fi.Mode() & os.ModeCharDevice) != 0
+}
+
+// stdin is the prompt source. Overridable for tests.
+var stdin io.Reader = os.Stdin
+
 func main() {
 	os.Exit(run(os.Args, version, os.Stdout, os.Stderr))
 }
@@ -34,6 +49,8 @@ func run(args []string, ver string, stdout, stderr io.Writer) int {
 			return runAudit(args[2:], stdout, stderr)
 		case "apply":
 			return runApply(args[2:], stdout, stderr)
+		case "enforce":
+			return runEnforce(args[2:], stdout, stderr)
 		}
 	}
 
@@ -48,8 +65,73 @@ func run(args []string, ver string, stdout, stderr io.Writer) int {
 		return 0
 	}
 
-	fmt.Fprintln(stderr, "usage: ghsecretman <audit|apply> --config <path> --org <name> --repo <name>")
+	fmt.Fprintln(stderr, "usage: ghsecretman <audit|apply|enforce> --config <path> --org <name> --repo <name>")
 	return 2
+}
+
+func runEnforce(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("enforce", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	cfgPath := fs.String("config", "", "path to YAML config file")
+	org := fs.String("org", "", "GitHub organization name")
+	repo := fs.String("repo", "", "single repo to enforce")
+	dryRun := fs.Bool("dry-run", false, "print intended writes and deletes; make no API write calls")
+	yes := fs.Bool("yes", false, "proceed without confirmation prompt")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if *cfgPath == "" || *org == "" || *repo == "" {
+		fmt.Fprintln(stderr, "enforce: --config, --org, and --repo are required")
+		return 2
+	}
+
+	cfg, err := config.Load(*cfgPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "load config: %v\n", err)
+		return 2
+	}
+
+	backend, err := backendFactory()
+	if err != nil {
+		fmt.Fprintf(stderr, "github: %v\n", err)
+		return 2
+	}
+
+	opts := runner.EnforceOptions{DryRun: *dryRun}
+	if !*dryRun && !*yes {
+		if !isTTY() {
+			fmt.Fprintln(stderr, "enforce: refusing to run on non-interactive stdin without --yes")
+			return 2
+		}
+		opts.Confirm = func(extras []string) bool {
+			return promptDeletions(stdin, stdout, *org, *repo, extras)
+		}
+	}
+
+	res, err := runner.EnforceRepo(context.Background(), cfg, *org, *repo, backend, stdout, opts)
+	if err != nil {
+		fmt.Fprintf(stderr, "enforce: %v\n", err)
+		return 1
+	}
+	if res.Failed > 0 {
+		return 1
+	}
+	return 0
+}
+
+func promptDeletions(in io.Reader, out io.Writer, org, repo string, extras []string) bool {
+	fmt.Fprintf(out, "About to delete %d entries on %s/%s:\n", len(extras), org, repo)
+	for _, x := range extras {
+		fmt.Fprintf(out, "  - %s\n", x)
+	}
+	fmt.Fprint(out, "Proceed? [y/N]: ")
+	r := bufio.NewReader(in)
+	line, err := r.ReadString('\n')
+	if err != nil && line == "" {
+		return false
+	}
+	line = strings.TrimSpace(strings.ToLower(line))
+	return line == "y" || line == "yes"
 }
 
 func runAudit(args []string, stdout, stderr io.Writer) int {

--- a/cmd/ghsecretman/main_test.go
+++ b/cmd/ghsecretman/main_test.go
@@ -153,6 +153,20 @@ func swapBackend(t *testing.T, be gh.Backend, beErr error) {
 	t.Cleanup(func() { backendFactory = prev })
 }
 
+func swapTTY(t *testing.T, val bool) {
+	t.Helper()
+	prev := isTTY
+	isTTY = func() bool { return val }
+	t.Cleanup(func() { isTTY = prev })
+}
+
+func swapStdin(t *testing.T, input string) {
+	t.Helper()
+	prev := stdin
+	stdin = strings.NewReader(input)
+	t.Cleanup(func() { stdin = prev })
+}
+
 func TestRun_AuditClean(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := writeCfg(t, dir, `
@@ -353,6 +367,208 @@ github.com:
 	swapBackend(t, &fakeBackend{}, nil)
 	var stdout, stderr bytes.Buffer
 	code := run([]string{"ghsecretman", "apply", "--config", cfgPath, "--org", "example", "--repo", "nope"}, "dev", &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit: got %d want 1", code)
+	}
+}
+
+func TestRun_EnforceDryRun_NoWrites(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeCfg(t, dir, `
+github.com:
+  example:
+    per-repo:
+      acme:
+        managed:
+          vars:
+            V:
+              value: ok
+`)
+	be := &fakeBackend{vars: map[string]string{"V_EXTRA": "x"}}
+	swapBackend(t, be, nil)
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"ghsecretman", "enforce", "--config", cfgPath, "--org", "example", "--repo", "acme", "--dry-run"},
+		"dev", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit: got %d want 0; stderr=%q", code, stderr.String())
+	}
+	if len(be.setVars)+len(be.delVars) != 0 {
+		t.Errorf("dry-run made writes: setVars=%v delVars=%v", be.setVars, be.delVars)
+	}
+	if !strings.Contains(stdout.String(), "would-delete") {
+		t.Errorf("expected would-delete in dry-run output: %q", stdout.String())
+	}
+}
+
+func TestRun_EnforceWithYes_DeletesExtras(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeCfg(t, dir, `
+github.com:
+  example:
+    per-repo:
+      acme:
+        managed:
+          vars:
+            V:
+              value: ok
+`)
+	be := &fakeBackend{vars: map[string]string{"V_EXTRA": "x"}}
+	swapBackend(t, be, nil)
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"ghsecretman", "enforce", "--config", cfgPath, "--org", "example", "--repo", "acme", "--yes"},
+		"dev", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit: got %d want 0; stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if len(be.delVars) != 1 || be.delVars[0] != "V_EXTRA" {
+		t.Errorf("expected V_EXTRA deleted; got %v", be.delVars)
+	}
+	if len(be.setVars) != 1 || be.setVars[0] != "V" {
+		t.Errorf("expected V set; got %v", be.setVars)
+	}
+}
+
+func TestRun_EnforceWithoutYes_NonTTY_Refuses(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeCfg(t, dir, `
+github.com:
+  example:
+    per-repo:
+      acme:
+        managed: {}
+`)
+	be := &fakeBackend{}
+	swapBackend(t, be, nil)
+	swapTTY(t, false)
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"ghsecretman", "enforce", "--config", cfgPath, "--org", "example", "--repo", "acme"},
+		"dev", &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("expected non-zero exit when no --yes and stdin is non-TTY")
+	}
+	if !strings.Contains(stderr.String(), "--yes") {
+		t.Errorf("stderr should mention --yes requirement: %q", stderr.String())
+	}
+	if len(be.delVars)+len(be.setVars) != 0 {
+		t.Errorf("no writes should have happened: setVars=%v delVars=%v", be.setVars, be.delVars)
+	}
+}
+
+func TestRun_EnforceTTYPromptYes_Proceeds(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeCfg(t, dir, `
+github.com:
+  example:
+    per-repo:
+      acme:
+        managed: {}
+`)
+	be := &fakeBackend{vars: map[string]string{"V_EXTRA": "x"}}
+	swapBackend(t, be, nil)
+	swapTTY(t, true)
+	swapStdin(t, "y\n")
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"ghsecretman", "enforce", "--config", cfgPath, "--org", "example", "--repo", "acme"},
+		"dev", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit: got %d want 0; stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	}
+	if len(be.delVars) != 1 || be.delVars[0] != "V_EXTRA" {
+		t.Errorf("expected V_EXTRA deleted; got %v", be.delVars)
+	}
+	if !strings.Contains(stdout.String(), "V_EXTRA") {
+		t.Errorf("expected prompt to mention V_EXTRA: %q", stdout.String())
+	}
+}
+
+func TestRun_EnforceTTYPromptNo_AbortsWithoutWrites(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeCfg(t, dir, `
+github.com:
+  example:
+    per-repo:
+      acme:
+        managed: {}
+`)
+	be := &fakeBackend{vars: map[string]string{"V_EXTRA": "x"}}
+	swapBackend(t, be, nil)
+	swapTTY(t, true)
+	swapStdin(t, "n\n")
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"ghsecretman", "enforce", "--config", cfgPath, "--org", "example", "--repo", "acme"},
+		"dev", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit: got %d want 0", code)
+	}
+	if len(be.delVars)+len(be.setVars) != 0 {
+		t.Errorf("declining at the prompt must skip all writes: setVars=%v delVars=%v",
+			be.setVars, be.delVars)
+	}
+}
+
+func TestRun_EnforceMissingFlags(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"ghsecretman", "enforce"}, "dev", &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("exit: got %d want 2", code)
+	}
+	if !strings.Contains(stderr.String(), "required") {
+		t.Fatalf("stderr should mention required: %q", stderr.String())
+	}
+}
+
+func TestRun_EnforceBadConfig(t *testing.T) {
+	swapBackend(t, &fakeBackend{}, nil)
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"ghsecretman", "enforce", "--config", "/no/such/file.yml", "--org", "example", "--repo", "acme", "--yes"},
+		"dev", &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("exit: got %d want 2", code)
+	}
+}
+
+func TestRun_EnforceBackendError(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeCfg(t, dir, `
+github.com:
+  example:
+    per-repo:
+      acme:
+        managed: {}
+`)
+	swapBackend(t, nil, errors.New("no token"))
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"ghsecretman", "enforce", "--config", cfgPath, "--org", "example", "--repo", "acme", "--yes"},
+		"dev", &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("exit: got %d want 2", code)
+	}
+}
+
+func TestRun_EnforceBadFlag(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"ghsecretman", "enforce", "--bogus"}, "dev", &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("exit: got %d want 2", code)
+	}
+}
+
+func TestRun_EnforceUnknownRepo(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeCfg(t, dir, `
+github.com:
+  example:
+    per-repo: {}
+`)
+	swapBackend(t, &fakeBackend{}, nil)
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"ghsecretman", "enforce", "--config", cfgPath, "--org", "example", "--repo", "nope", "--yes"},
+		"dev", &stdout, &stderr)
 	if code != 1 {
 		t.Fatalf("exit: got %d want 1", code)
 	}

--- a/cmd/ghsecretman/main_test.go
+++ b/cmd/ghsecretman/main_test.go
@@ -78,6 +78,10 @@ type fakeBackend struct {
 	setVars       []string
 	setSecrets    []string
 	setDependabot []string
+
+	delVars       []string
+	delSecrets    []string
+	delDependabot []string
 }
 
 func (f *fakeBackend) ListRepoVariables(_ context.Context, _, _ string) (map[string]string, error) {
@@ -110,6 +114,21 @@ func (f *fakeBackend) SetRepoSecret(_ context.Context, _, _, name string, _ *gh.
 
 func (f *fakeBackend) SetRepoDependabotSecret(_ context.Context, _, _, name string, _ *gh.PublicKey, _ string) error {
 	f.setDependabot = append(f.setDependabot, name)
+	return nil
+}
+
+func (f *fakeBackend) DeleteRepoVariable(_ context.Context, _, _, name string) error {
+	f.delVars = append(f.delVars, name)
+	return nil
+}
+
+func (f *fakeBackend) DeleteRepoSecret(_ context.Context, _, _, name string) error {
+	f.delSecrets = append(f.delSecrets, name)
+	return nil
+}
+
+func (f *fakeBackend) DeleteRepoDependabotSecret(_ context.Context, _, _, name string) error {
+	f.delDependabot = append(f.delDependabot, name)
 	return nil
 }
 

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -28,6 +28,10 @@ type Backend interface {
 	SetRepoVariable(ctx context.Context, owner, repo, name, value string) error
 	SetRepoSecret(ctx context.Context, owner, repo, name string, key *PublicKey, plaintext string) error
 	SetRepoDependabotSecret(ctx context.Context, owner, repo, name string, key *PublicKey, plaintext string) error
+
+	DeleteRepoVariable(ctx context.Context, owner, repo, name string) error
+	DeleteRepoSecret(ctx context.Context, owner, repo, name string) error
+	DeleteRepoDependabotSecret(ctx context.Context, owner, repo, name string) error
 }
 
 // Client is the live GitHub backend.
@@ -158,6 +162,30 @@ func (c *Client) SetRepoDependabotSecret(ctx context.Context, owner, repo, name 
 	es := &gogithub.DependabotEncryptedSecret{Name: name, KeyID: key.KeyID, EncryptedValue: enc}
 	if _, err := c.gh.Dependabot.CreateOrUpdateRepoSecret(ctx, owner, repo, es); err != nil {
 		return fmt.Errorf("set repo dependabot secret %s: %w", name, err)
+	}
+	return nil
+}
+
+// DeleteRepoVariable deletes a repo Actions variable.
+func (c *Client) DeleteRepoVariable(ctx context.Context, owner, repo, name string) error {
+	if _, err := c.gh.Actions.DeleteRepoVariable(ctx, owner, repo, name); err != nil {
+		return fmt.Errorf("delete repo variable %s: %w", name, err)
+	}
+	return nil
+}
+
+// DeleteRepoSecret deletes a repo Actions secret.
+func (c *Client) DeleteRepoSecret(ctx context.Context, owner, repo, name string) error {
+	if _, err := c.gh.Actions.DeleteRepoSecret(ctx, owner, repo, name); err != nil {
+		return fmt.Errorf("delete repo secret %s: %w", name, err)
+	}
+	return nil
+}
+
+// DeleteRepoDependabotSecret deletes a repo Dependabot secret.
+func (c *Client) DeleteRepoDependabotSecret(ctx context.Context, owner, repo, name string) error {
+	if _, err := c.gh.Dependabot.DeleteRepoSecret(ctx, owner, repo, name); err != nil {
+		return fmt.Errorf("delete repo dependabot secret %s: %w", name, err)
 	}
 	return nil
 }

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -409,6 +409,105 @@ func TestClient_SetRepoDependabotSecret_APIError(t *testing.T) {
 	}
 }
 
+func TestClient_DeleteRepoVariable(t *testing.T) {
+	t.Parallel()
+	var captured struct{ method, path string }
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.method = r.Method
+		captured.path = r.URL.Path
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+	c := newClientPointingAt(t, srv.URL)
+	if err := c.DeleteRepoVariable(context.Background(), "example", "acme", "V"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if captured.method != http.MethodDelete {
+		t.Errorf("method: got %s want DELETE", captured.method)
+	}
+	if captured.path != "/repos/example/acme/actions/variables/V" {
+		t.Errorf("path: %s", captured.path)
+	}
+}
+
+func TestClient_DeleteRepoVariable_Error(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"nope"}`, http.StatusForbidden)
+	}))
+	defer srv.Close()
+	c := newClientPointingAt(t, srv.URL)
+	if err := c.DeleteRepoVariable(context.Background(), "example", "acme", "V"); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestClient_DeleteRepoSecret(t *testing.T) {
+	t.Parallel()
+	var captured struct{ method, path string }
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.method = r.Method
+		captured.path = r.URL.Path
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+	c := newClientPointingAt(t, srv.URL)
+	if err := c.DeleteRepoSecret(context.Background(), "example", "acme", "S"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if captured.method != http.MethodDelete {
+		t.Errorf("method: got %s want DELETE", captured.method)
+	}
+	if captured.path != "/repos/example/acme/actions/secrets/S" {
+		t.Errorf("path: %s", captured.path)
+	}
+}
+
+func TestClient_DeleteRepoSecret_Error(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"nope"}`, http.StatusForbidden)
+	}))
+	defer srv.Close()
+	c := newClientPointingAt(t, srv.URL)
+	if err := c.DeleteRepoSecret(context.Background(), "example", "acme", "S"); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestClient_DeleteRepoDependabotSecret(t *testing.T) {
+	t.Parallel()
+	var captured struct{ method, path string }
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.method = r.Method
+		captured.path = r.URL.Path
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+	c := newClientPointingAt(t, srv.URL)
+	if err := c.DeleteRepoDependabotSecret(context.Background(), "example", "acme", "D"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if captured.method != http.MethodDelete {
+		t.Errorf("method: got %s want DELETE", captured.method)
+	}
+	if captured.path != "/repos/example/acme/dependabot/secrets/D" {
+		t.Errorf("path: %s", captured.path)
+	}
+}
+
+func TestClient_DeleteRepoDependabotSecret_Error(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"nope"}`, http.StatusForbidden)
+	}))
+	defer srv.Close()
+	c := newClientPointingAt(t, srv.URL)
+	if err := c.DeleteRepoDependabotSecret(context.Background(), "example", "acme", "D"); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
 func TestSealAnonymous_Roundtrip(t *testing.T) {
 	t.Parallel()
 	pub, priv := genBoxKeypair(t)

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -244,86 +244,108 @@ func EnforceRepo(ctx context.Context, cfg *config.Config, org, repo string, back
 
 	intents := plan.ForRepo(repo, r)
 
-	var resolved map[string]string
-	if !opts.DryRun {
-		var err error
-		resolved, err = resolveAll(intents)
-		if err != nil {
-			return Result{}, err
-		}
-	}
-
-	desiredVars := map[string]string{}
-	for _, in := range intents {
-		if in.Kind == plan.KindVar && in.Action == plan.ActionManaged {
-			desiredVars[in.Name] = resolved[entryKey(in)]
-		}
+	resolved, err := resolveForEnforce(intents, opts.DryRun)
+	if err != nil {
+		return Result{}, err
 	}
 
 	live, err := fetchLive(ctx, backend, org, repo)
 	if err != nil {
 		return Result{}, err
 	}
-	entries := diff.Compute(repo, intents, desiredVars, live, r.Ignored)
+	entries := diff.Compute(repo, intents, desiredVarsFromResolved(intents, resolved), live, r.Ignored)
 
-	if !opts.DryRun && opts.Confirm != nil {
-		extras := make([]string, 0)
-		for _, e := range entries {
-			if e.Status == diff.Extra {
-				extras = append(extras, fmt.Sprintf("%s/%s", e.Kind, e.Name))
-			}
-		}
-		if !opts.Confirm(extras) {
-			return Result{}, nil
-		}
+	if !opts.DryRun && opts.Confirm != nil && !opts.Confirm(extraKindNames(entries)) {
+		return Result{}, nil
 	}
 
-	var actionsKey, depKey *gh.PublicKey
-	if !opts.DryRun {
-		actionsKey, depKey, err = fetchKeys(ctx, backend, org, repo, intents)
-		if err != nil {
-			return Result{}, err
-		}
+	actionsKey, depKey, err := keysForEnforce(ctx, backend, org, repo, intents, opts.DryRun)
+	if err != nil {
+		return Result{}, err
 	}
 
 	fmt.Fprintf(out, "org: %s\nrepo: %s\n", org, repo)
 	res := Result{}
+	res.Failed += runApplyPhase(ctx, backend, org, repo, intents, resolved, actionsKey, depKey, out, opts.DryRun)
+	res.Failed += runDeletePhase(ctx, backend, org, repo, entries, out, opts.DryRun)
+	if res.Failed > 0 {
+		fmt.Fprintf(out, "summary: %d failed\n", res.Failed)
+	}
+	return res, nil
+}
+
+func resolveForEnforce(intents []plan.Intent, dryRun bool) (map[string]string, error) {
+	if dryRun {
+		return nil, nil
+	}
+	return resolveAll(intents)
+}
+
+func keysForEnforce(ctx context.Context, backend gh.Backend, org, repo string, intents []plan.Intent, dryRun bool) (*gh.PublicKey, *gh.PublicKey, error) {
+	if dryRun {
+		return nil, nil, nil
+	}
+	return fetchKeys(ctx, backend, org, repo, intents)
+}
+
+func desiredVarsFromResolved(intents []plan.Intent, resolved map[string]string) map[string]string {
+	out := map[string]string{}
+	for _, in := range intents {
+		if in.Kind == plan.KindVar && in.Action == plan.ActionManaged {
+			out[in.Name] = resolved[entryKey(in)]
+		}
+	}
+	return out
+}
+
+func extraKindNames(entries []diff.Entry) []string {
+	out := make([]string, 0)
+	for _, e := range entries {
+		if e.Status == diff.Extra {
+			out = append(out, fmt.Sprintf("%s/%s", e.Kind, e.Name))
+		}
+	}
+	return out
+}
+
+func runApplyPhase(ctx context.Context, backend gh.Backend, org, repo string, intents []plan.Intent, resolved map[string]string, actionsKey, depKey *gh.PublicKey, out io.Writer, dryRun bool) int {
+	failed := 0
 	for _, in := range intents {
 		if in.Action != plan.ActionManaged {
 			continue
 		}
-		if opts.DryRun {
+		if dryRun {
 			fmt.Fprintf(out, "  %s/%s: would-set\n", in.Kind, in.Name)
 			continue
 		}
 		if err := applyOne(ctx, backend, org, repo, in, resolved[entryKey(in)], actionsKey, depKey); err != nil {
-			res.Failed++
+			failed++
 			fmt.Fprintf(out, "  %s/%s: FAILED: %v\n", in.Kind, in.Name, err)
 			continue
 		}
 		fmt.Fprintf(out, "  %s/%s: ok\n", in.Kind, in.Name)
 	}
+	return failed
+}
 
+func runDeletePhase(ctx context.Context, backend gh.Backend, org, repo string, entries []diff.Entry, out io.Writer, dryRun bool) int {
+	failed := 0
 	for _, e := range entries {
 		if e.Status != diff.Extra {
 			continue
 		}
-		if opts.DryRun {
+		if dryRun {
 			fmt.Fprintf(out, "  %s/%s: would-delete\n", e.Kind, e.Name)
 			continue
 		}
 		if err := deleteOne(ctx, backend, org, repo, e.Kind, e.Name); err != nil {
-			res.Failed++
+			failed++
 			fmt.Fprintf(out, "  %s/%s: FAILED: %v\n", e.Kind, e.Name, err)
 			continue
 		}
 		fmt.Fprintf(out, "  %s/%s: deleted\n", e.Kind, e.Name)
 	}
-
-	if res.Failed > 0 {
-		fmt.Fprintf(out, "summary: %d failed\n", res.Failed)
-	}
-	return res, nil
+	return failed
 }
 
 func deleteOne(ctx context.Context, backend gh.Backend, org, repo string, kind plan.Kind, name string) error {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -210,6 +210,134 @@ func fetchKeys(ctx context.Context, backend gh.Backend, org, repo string, intent
 	return actions, dependabot, nil
 }
 
+// EnforceOptions controls EnforceRepo behavior.
+type EnforceOptions struct {
+	// DryRun prints planned set/delete actions and makes zero write API
+	// calls. The public-key fetch and value resolution are also skipped
+	// since neither is needed without a real write.
+	DryRun bool
+
+	// Confirm, if non-nil and DryRun is false, is invoked after the live
+	// state has been fetched and the extras list computed. The argument
+	// is a list of "kind/name" strings, one per planned deletion. If
+	// Confirm returns false, no writes or deletes are performed and
+	// Result is the zero value. Confirm is ignored when DryRun is true.
+	Confirm func(extras []string) bool
+}
+
+// EnforceRepo applies managed values and then deletes any "extra" entries
+// — entries present on the repo but not listed in either the managed or
+// ignored block. With DryRun=true, it prints intended set/delete lines
+// without calling any write API.
+//
+// The TTY/--yes confirmation contract is owned by the CLI layer; by the
+// time EnforceRepo is called, the caller has already decided to proceed.
+func EnforceRepo(ctx context.Context, cfg *config.Config, org, repo string, backend gh.Backend, out io.Writer, opts EnforceOptions) (Result, error) {
+	o, ok := cfg.Org(org)
+	if !ok {
+		return Result{}, fmt.Errorf("org %q not found in config", org)
+	}
+	r, ok := o.PerRepo[repo]
+	if !ok {
+		return Result{}, fmt.Errorf("repo %q not found under org %q", repo, org)
+	}
+
+	intents := plan.ForRepo(repo, r)
+
+	var resolved map[string]string
+	if !opts.DryRun {
+		var err error
+		resolved, err = resolveAll(intents)
+		if err != nil {
+			return Result{}, err
+		}
+	}
+
+	desiredVars := map[string]string{}
+	for _, in := range intents {
+		if in.Kind == plan.KindVar && in.Action == plan.ActionManaged {
+			desiredVars[in.Name] = resolved[entryKey(in)]
+		}
+	}
+
+	live, err := fetchLive(ctx, backend, org, repo)
+	if err != nil {
+		return Result{}, err
+	}
+	entries := diff.Compute(repo, intents, desiredVars, live, r.Ignored)
+
+	if !opts.DryRun && opts.Confirm != nil {
+		extras := make([]string, 0)
+		for _, e := range entries {
+			if e.Status == diff.Extra {
+				extras = append(extras, fmt.Sprintf("%s/%s", e.Kind, e.Name))
+			}
+		}
+		if !opts.Confirm(extras) {
+			return Result{}, nil
+		}
+	}
+
+	var actionsKey, depKey *gh.PublicKey
+	if !opts.DryRun {
+		actionsKey, depKey, err = fetchKeys(ctx, backend, org, repo, intents)
+		if err != nil {
+			return Result{}, err
+		}
+	}
+
+	fmt.Fprintf(out, "org: %s\nrepo: %s\n", org, repo)
+	res := Result{}
+	for _, in := range intents {
+		if in.Action != plan.ActionManaged {
+			continue
+		}
+		if opts.DryRun {
+			fmt.Fprintf(out, "  %s/%s: would-set\n", in.Kind, in.Name)
+			continue
+		}
+		if err := applyOne(ctx, backend, org, repo, in, resolved[entryKey(in)], actionsKey, depKey); err != nil {
+			res.Failed++
+			fmt.Fprintf(out, "  %s/%s: FAILED: %v\n", in.Kind, in.Name, err)
+			continue
+		}
+		fmt.Fprintf(out, "  %s/%s: ok\n", in.Kind, in.Name)
+	}
+
+	for _, e := range entries {
+		if e.Status != diff.Extra {
+			continue
+		}
+		if opts.DryRun {
+			fmt.Fprintf(out, "  %s/%s: would-delete\n", e.Kind, e.Name)
+			continue
+		}
+		if err := deleteOne(ctx, backend, org, repo, e.Kind, e.Name); err != nil {
+			res.Failed++
+			fmt.Fprintf(out, "  %s/%s: FAILED: %v\n", e.Kind, e.Name, err)
+			continue
+		}
+		fmt.Fprintf(out, "  %s/%s: deleted\n", e.Kind, e.Name)
+	}
+
+	if res.Failed > 0 {
+		fmt.Fprintf(out, "summary: %d failed\n", res.Failed)
+	}
+	return res, nil
+}
+
+func deleteOne(ctx context.Context, backend gh.Backend, org, repo string, kind plan.Kind, name string) error {
+	switch kind {
+	case plan.KindVar:
+		return backend.DeleteRepoVariable(ctx, org, repo, name)
+	case plan.KindSecret:
+		return backend.DeleteRepoSecret(ctx, org, repo, name)
+	case plan.KindDependabot:
+		return backend.DeleteRepoDependabotSecret(ctx, org, repo, name)
+	}
+	return fmt.Errorf("unknown kind %q", kind)
+}
+
 // writeFile is a thin wrapper used by tests to materialize fixture YAML.
 func writeFile(path string, data []byte) error {
 	return os.WriteFile(path, data, 0o600)

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -840,6 +840,433 @@ github.com:
 	}
 }
 
+func TestEnforceRepo_DeletesExtrasAndAppliesManaged(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "secrets.yml")
+	if err := writeFile(cfgPath, []byte(`
+github.com:
+  example:
+    per-repo:
+      acme:
+        managed:
+          vars:
+            V_KEEP:
+              value: ok
+          secrets:
+            S_KEEP:
+              value: ok
+          dependabot:
+            D_KEEP:
+              value: ok
+`)); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	be := &fakeBackend{
+		vars:       map[string]string{"V_KEEP": "ok", "V_EXTRA1": "x", "V_EXTRA2": "y"},
+		secrets:    []string{"S_KEEP", "S_EXTRA"},
+		dependabot: []string{"D_KEEP", "D_EXTRA"},
+	}
+	var out bytes.Buffer
+	res, err := EnforceRepo(context.Background(), cfg, "example", "acme", be, &out, EnforceOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Failed != 0 {
+		t.Errorf("expected zero failures, got %d", res.Failed)
+	}
+	if !equalSorted(be.delVarCalls, []string{"V_EXTRA1", "V_EXTRA2"}) {
+		t.Errorf("var deletes: got %v want [V_EXTRA1 V_EXTRA2]", be.delVarCalls)
+	}
+	if !equalSorted(be.delSecCalls, []string{"S_EXTRA"}) {
+		t.Errorf("secret deletes: got %v want [S_EXTRA]", be.delSecCalls)
+	}
+	if !equalSorted(be.delDepCalls, []string{"D_EXTRA"}) {
+		t.Errorf("dependabot deletes: got %v want [D_EXTRA]", be.delDepCalls)
+	}
+	if !equalSorted(callNames(be.setVarCalls), []string{"V_KEEP"}) {
+		t.Errorf("var sets: got %v", callNames(be.setVarCalls))
+	}
+	if !equalSorted(secretCallNames(be.setSecCalls), []string{"S_KEEP"}) {
+		t.Errorf("secret sets: got %v", secretCallNames(be.setSecCalls))
+	}
+	if !equalSorted(secretCallNames(be.setDepCalls), []string{"D_KEEP"}) {
+		t.Errorf("dependabot sets: got %v", secretCallNames(be.setDepCalls))
+	}
+
+	s := out.String()
+	for _, want := range []string{
+		"repo: acme",
+		"vars/V_KEEP: ok",
+		"vars/V_EXTRA1: deleted",
+		"secrets/S_EXTRA: deleted",
+		"dependabot/D_EXTRA: deleted",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("output missing %q\n--\n%s", want, s)
+		}
+	}
+}
+
+func TestEnforceRepo_IgnoredExtrasNotDeleted(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "secrets.yml")
+	if err := writeFile(cfgPath, []byte(`
+github.com:
+  example:
+    per-repo:
+      acme:
+        managed:
+          vars:
+            V_KEEP:
+              value: ok
+        ignored:
+          vars:
+            - V_LEAVE_ALONE
+          secrets:
+            - S_LEAVE_ALONE
+          dependabot:
+            - D_LEAVE_ALONE
+`)); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	be := &fakeBackend{
+		vars:       map[string]string{"V_KEEP": "ok", "V_LEAVE_ALONE": "x", "V_EXTRA": "y"},
+		secrets:    []string{"S_LEAVE_ALONE", "S_EXTRA"},
+		dependabot: []string{"D_LEAVE_ALONE"},
+	}
+	var out bytes.Buffer
+	if _, err := EnforceRepo(context.Background(), cfg, "example", "acme", be, &out, EnforceOptions{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, n := range be.delVarCalls {
+		if n == "V_LEAVE_ALONE" {
+			t.Errorf("ignored var V_LEAVE_ALONE should not be deleted; got %v", be.delVarCalls)
+		}
+	}
+	for _, n := range be.delSecCalls {
+		if n == "S_LEAVE_ALONE" {
+			t.Errorf("ignored secret S_LEAVE_ALONE should not be deleted; got %v", be.delSecCalls)
+		}
+	}
+	for _, n := range be.delDepCalls {
+		if n == "D_LEAVE_ALONE" {
+			t.Errorf("ignored dependabot D_LEAVE_ALONE should not be deleted; got %v", be.delDepCalls)
+		}
+	}
+	if !equalSorted(be.delVarCalls, []string{"V_EXTRA"}) {
+		t.Errorf("var deletes: got %v want [V_EXTRA]", be.delVarCalls)
+	}
+	if !equalSorted(be.delSecCalls, []string{"S_EXTRA"}) {
+		t.Errorf("secret deletes: got %v want [S_EXTRA]", be.delSecCalls)
+	}
+	if len(be.delDepCalls) != 0 {
+		t.Errorf("dependabot deletes: got %v want []", be.delDepCalls)
+	}
+	s := out.String()
+	for _, name := range []string{"V_LEAVE_ALONE", "S_LEAVE_ALONE", "D_LEAVE_ALONE"} {
+		if strings.Contains(s, name) {
+			t.Errorf("ignored name %q must not appear in enforce output:\n%s", name, s)
+		}
+	}
+}
+
+func TestEnforceRepo_DryRunSkipsAllWrites(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "secrets.yml")
+	if err := writeFile(cfgPath, []byte(`
+github.com:
+  example:
+    per-repo:
+      acme:
+        managed:
+          vars:
+            V_KEEP:
+              value: ok
+          secrets:
+            S_KEEP:
+              value: ok
+`)); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	be := &fakeBackend{
+		vars:    map[string]string{"V_EXTRA": "x"},
+		secrets: []string{"S_EXTRA"},
+	}
+	var out bytes.Buffer
+	res, err := EnforceRepo(context.Background(), cfg, "example", "acme", be, &out, EnforceOptions{DryRun: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Failed != 0 {
+		t.Errorf("expected zero failures, got %d", res.Failed)
+	}
+	if len(be.setVarCalls)+len(be.setSecCalls)+len(be.setDepCalls) != 0 {
+		t.Errorf("dry-run made set calls: vars=%v secs=%v deps=%v",
+			be.setVarCalls, be.setSecCalls, be.setDepCalls)
+	}
+	if len(be.delVarCalls)+len(be.delSecCalls)+len(be.delDepCalls) != 0 {
+		t.Errorf("dry-run made delete calls: vars=%v secs=%v deps=%v",
+			be.delVarCalls, be.delSecCalls, be.delDepCalls)
+	}
+	if be.actionsKeyFetches != 0 || be.dependabotKeyFetches != 0 {
+		t.Errorf("dry-run should not fetch public keys; actions=%d dep=%d",
+			be.actionsKeyFetches, be.dependabotKeyFetches)
+	}
+	s := out.String()
+	for _, want := range []string{
+		"vars/V_KEEP: would-set",
+		"secrets/S_KEEP: would-set",
+		"vars/V_EXTRA: would-delete",
+		"secrets/S_EXTRA: would-delete",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("dry-run output missing %q\n--\n%s", want, s)
+		}
+	}
+}
+
+func TestEnforceRepo_DryRunDoesNotResolve(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "secrets.yml")
+	if err := writeFile(cfgPath, []byte(`
+github.com:
+  example:
+    per-repo:
+      acme:
+        managed:
+          vars:
+            V:
+              env: GHSM_TEST_ENFORCE_DRYRUN_NEVER_SET
+`)); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	be := &fakeBackend{}
+	if _, err := EnforceRepo(context.Background(), cfg, "example", "acme", be, &bytes.Buffer{}, EnforceOptions{DryRun: true}); err != nil {
+		t.Fatalf("dry-run should not require value resolution; got: %v", err)
+	}
+}
+
+func TestEnforceRepo_DeleteFailureContinues(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "secrets.yml")
+	if err := writeFile(cfgPath, []byte(`
+github.com:
+  example:
+    per-repo:
+      acme:
+        managed: {}
+`)); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	be := &fakeBackend{
+		vars:   map[string]string{"V_BAD": "x", "V_GOOD": "y"},
+		delErr: map[string]error{"vars/V_BAD": errors.New("boom")},
+	}
+	var out bytes.Buffer
+	res, err := EnforceRepo(context.Background(), cfg, "example", "acme", be, &out, EnforceOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Failed != 1 {
+		t.Errorf("expected 1 failure, got %d", res.Failed)
+	}
+	if !equalSorted(be.delVarCalls, []string{"V_GOOD"}) {
+		t.Errorf("V_GOOD should still be deleted after V_BAD failed: got %v", be.delVarCalls)
+	}
+	s := out.String()
+	if !strings.Contains(s, "vars/V_BAD: FAILED: boom") {
+		t.Errorf("output missing failure line:\n%s", s)
+	}
+	if !strings.Contains(s, "summary: 1 failed") {
+		t.Errorf("output missing summary line:\n%s", s)
+	}
+}
+
+func TestEnforceRepo_ConfirmCallbackReceivesExtras(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "secrets.yml")
+	if err := writeFile(cfgPath, []byte(`
+github.com:
+  example:
+    per-repo:
+      acme:
+        managed: {}
+`)); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	be := &fakeBackend{
+		vars:       map[string]string{"V_X": "x"},
+		secrets:    []string{"S_X"},
+		dependabot: []string{"D_X"},
+	}
+	var got []string
+	confirm := func(extras []string) bool {
+		got = append([]string(nil), extras...)
+		return true
+	}
+	if _, err := EnforceRepo(context.Background(), cfg, "example", "acme", be, &bytes.Buffer{},
+		EnforceOptions{Confirm: confirm}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !equalSorted(got, []string{"vars/V_X", "secrets/S_X", "dependabot/D_X"}) {
+		t.Errorf("Confirm got %v, want sorted-equal of [vars/V_X secrets/S_X dependabot/D_X]", got)
+	}
+	if len(be.delVarCalls) != 1 || len(be.delSecCalls) != 1 || len(be.delDepCalls) != 1 {
+		t.Errorf("expected one delete per kind after confirm=true; got vars=%v secs=%v deps=%v",
+			be.delVarCalls, be.delSecCalls, be.delDepCalls)
+	}
+}
+
+func TestEnforceRepo_ConfirmFalseSkipsAllWrites(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "secrets.yml")
+	if err := writeFile(cfgPath, []byte(`
+github.com:
+  example:
+    per-repo:
+      acme:
+        managed:
+          vars:
+            V_KEEP:
+              value: ok
+`)); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	be := &fakeBackend{vars: map[string]string{"V_X": "x"}}
+	confirm := func(_ []string) bool { return false }
+	res, err := EnforceRepo(context.Background(), cfg, "example", "acme", be, &bytes.Buffer{},
+		EnforceOptions{Confirm: confirm})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Failed != 0 {
+		t.Errorf("Failed should be 0 when confirm declined")
+	}
+	if len(be.setVarCalls)+len(be.delVarCalls) != 0 {
+		t.Errorf("confirm=false must skip all writes; sets=%v dels=%v", be.setVarCalls, be.delVarCalls)
+	}
+	if be.actionsKeyFetches != 0 {
+		t.Errorf("public key should not be fetched when confirm declines; got %d", be.actionsKeyFetches)
+	}
+}
+
+func TestEnforceRepo_DryRunIgnoresConfirm(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "secrets.yml")
+	if err := writeFile(cfgPath, []byte(`
+github.com:
+  example:
+    per-repo:
+      acme:
+        managed: {}
+`)); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	be := &fakeBackend{vars: map[string]string{"V_X": "x"}}
+	called := false
+	confirm := func(_ []string) bool {
+		called = true
+		return false
+	}
+	if _, err := EnforceRepo(context.Background(), cfg, "example", "acme", be, &bytes.Buffer{},
+		EnforceOptions{DryRun: true, Confirm: confirm}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if called {
+		t.Errorf("Confirm must not be invoked when DryRun is true")
+	}
+}
+
+func TestEnforceRepo_UnknownOrgRepo(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{Orgs: map[string]*config.Org{}}
+	if _, err := EnforceRepo(context.Background(), cfg, "missing", "acme", &fakeBackend{}, &bytes.Buffer{}, EnforceOptions{}); err == nil {
+		t.Fatal("expected error for unknown org")
+	}
+	cfg.Orgs["example"] = &config.Org{PerRepo: map[string]*config.Repo{}}
+	if _, err := EnforceRepo(context.Background(), cfg, "example", "missing", &fakeBackend{}, &bytes.Buffer{}, EnforceOptions{}); err == nil {
+		t.Fatal("expected error for unknown repo")
+	}
+}
+
+func TestEnforceRepo_BackendListError(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{
+		Orgs: map[string]*config.Org{
+			"example": {PerRepo: map[string]*config.Repo{"acme": {}}},
+		},
+	}
+	be := &fakeBackend{err: errors.New("boom")}
+	if _, err := EnforceRepo(context.Background(), cfg, "example", "acme", be, &bytes.Buffer{}, EnforceOptions{}); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestEnforceRepo_ResolveErrorWhenLive(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "secrets.yml")
+	if err := writeFile(cfgPath, []byte(`
+github.com:
+  example:
+    per-repo:
+      acme:
+        managed:
+          vars:
+            V:
+              file: missing.txt
+`)); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := EnforceRepo(context.Background(), cfg, "example", "acme", &fakeBackend{}, &bytes.Buffer{}, EnforceOptions{}); err == nil {
+		t.Fatal("expected resolve error in live enforce mode")
+	}
+}
+
 func TestAuditRepo_ShowIgnored(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -34,12 +34,18 @@ type fakeBackend struct {
 	setSecCalls []setSecretCall
 	setDepCalls []setSecretCall
 
+	delVarCalls []string
+	delSecCalls []string
+	delDepCalls []string
+
 	// keyFetchCount tracks how many times each key fetch endpoint was called.
 	actionsKeyFetches    int
 	dependabotKeyFetches int
 
 	// setErr injects errors for specific (kind, name) pairs.
 	setErr map[string]error
+	// delErr injects errors for specific (kind, name) pairs on delete.
+	delErr map[string]error
 }
 
 type setVarCall struct {
@@ -125,6 +131,36 @@ func (f *fakeBackend) SetRepoDependabotSecret(_ context.Context, owner, repo, na
 		keyID = key.KeyID
 	}
 	f.setDepCalls = append(f.setDepCalls, setSecretCall{owner, repo, name, plaintext, keyID})
+	return nil
+}
+
+func (f *fakeBackend) DeleteRepoVariable(_ context.Context, _, _, name string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if e, ok := f.delErr["vars/"+name]; ok {
+		return e
+	}
+	f.delVarCalls = append(f.delVarCalls, name)
+	return nil
+}
+
+func (f *fakeBackend) DeleteRepoSecret(_ context.Context, _, _, name string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if e, ok := f.delErr["secrets/"+name]; ok {
+		return e
+	}
+	f.delSecCalls = append(f.delSecCalls, name)
+	return nil
+}
+
+func (f *fakeBackend) DeleteRepoDependabotSecret(_ context.Context, _, _, name string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if e, ok := f.delErr["dependabot/"+name]; ok {
+		return e
+	}
+	f.delDepCalls = append(f.delDepCalls, name)
 	return nil
 }
 


### PR DESCRIPTION
Fixes #7

Adds the `enforce` subcommand: `apply` semantics plus deletion of "extra"
entries on the live repo (present on GitHub, not listed in `managed`,
not listed in `ignored`).

## What changed

- `internal/github`: new `DeleteRepoVariable`, `DeleteRepoSecret`, and
  `DeleteRepoDependabotSecret` ops on the Backend interface and Client,
  with httptest coverage of method+path and an API error mapping for each.
- `internal/runner`: new `EnforceRepo` and `EnforceOptions{DryRun, Confirm}`.
  Apply phase writes managed entries; delete phase removes only entries
  the diff engine flagged as `Extra` (so `ignored` entries are
  intrinsically protected). DryRun skips value resolution, the public-key
  fetch, and every write API call. Confirm receives the planned-deletion
  list and aborts both phases if it returns false.
- `cmd/ghsecretman`: `enforce` subcommand with `--dry-run` and `--yes`.
  Without `--yes`: prompts y/N on a TTY listing each planned deletion,
  refuses outright on non-TTY stdin.

## Test plan

- [x] `go test ./...` passes
- [x] `go test ./... -cover` ≥ 80% per package (lowest is config @ 91.4%)
- [x] `golangci-lint run` clean