### PR TITLE
runner,cli: all-repos cascade and org-wide iteration

### DIFF
--- a/cmd/ghsecretman/main.go
+++ b/cmd/ghsecretman/main.go
@@ -74,14 +74,14 @@ func runEnforce(args []string, stdout, stderr io.Writer) int {
 	fs.SetOutput(stderr)
 	cfgPath := fs.String("config", "", "path to YAML config file")
 	org := fs.String("org", "", "GitHub organization name")
-	repo := fs.String("repo", "", "single repo to enforce")
+	repo := fs.String("repo", "", "single repo to enforce; omit to iterate every repo in the org")
 	dryRun := fs.Bool("dry-run", false, "print intended writes and deletes; make no API write calls")
 	yes := fs.Bool("yes", false, "proceed without confirmation prompt")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
-	if *cfgPath == "" || *org == "" || *repo == "" {
-		fmt.Fprintln(stderr, "enforce: --config, --org, and --repo are required")
+	if *cfgPath == "" || *org == "" {
+		fmt.Fprintln(stderr, "enforce: --config and --org are required")
 		return 2
 	}
 
@@ -97,23 +97,55 @@ func runEnforce(args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 
-	opts := runner.EnforceOptions{DryRun: *dryRun}
-	if !*dryRun && !*yes {
-		if !isTTY() {
-			fmt.Fprintln(stderr, "enforce: refusing to run on non-interactive stdin without --yes")
-			return 2
-		}
-		opts.Confirm = func(extras []string) bool {
-			return promptDeletions(stdin, stdout, *org, *repo, extras)
-		}
+	opts, code := buildEnforceOptions(*org, *repo, *dryRun, *yes, stdout, stderr)
+	if code != 0 {
+		return code
 	}
 
-	res, err := runner.EnforceRepo(context.Background(), cfg, *org, *repo, backend, stdout, opts)
+	if *repo != "" {
+		return runEnforceRepo(cfg, *org, *repo, backend, opts, stdout, stderr)
+	}
+	return runEnforceOrg(cfg, *org, backend, opts, stdout, stderr)
+}
+
+func buildEnforceOptions(org, repo string, dryRun, yes bool, stdout, stderr io.Writer) (runner.EnforceOptions, int) {
+	opts := runner.EnforceOptions{DryRun: dryRun}
+	if dryRun || yes {
+		return opts, 0
+	}
+	if !isTTY() {
+		fmt.Fprintln(stderr, "enforce: refusing to run on non-interactive stdin without --yes")
+		return opts, 2
+	}
+	target := repo
+	if target == "" {
+		target = "all repos in " + org
+	}
+	opts.Confirm = func(extras []string) bool {
+		return promptDeletions(stdin, stdout, org, target, extras)
+	}
+	return opts, 0
+}
+
+func runEnforceRepo(cfg *config.Config, org, repo string, backend gh.Backend, opts runner.EnforceOptions, stdout, stderr io.Writer) int {
+	res, err := runner.EnforceRepo(context.Background(), cfg, org, repo, backend, stdout, opts)
 	if err != nil {
 		fmt.Fprintf(stderr, "enforce: %v\n", err)
 		return 1
 	}
 	if res.Failed > 0 {
+		return 1
+	}
+	return 0
+}
+
+func runEnforceOrg(cfg *config.Config, org string, backend gh.Backend, opts runner.EnforceOptions, stdout, stderr io.Writer) int {
+	res, err := runner.Enforce(context.Background(), cfg, org, backend, stdout, opts)
+	if err != nil {
+		fmt.Fprintf(stderr, "enforce: %v\n", err)
+		return 1
+	}
+	if res.FailedEntries > 0 || res.FailedRepos > 0 {
 		return 1
 	}
 	return 0
@@ -139,13 +171,13 @@ func runAudit(args []string, stdout, stderr io.Writer) int {
 	fs.SetOutput(stderr)
 	cfgPath := fs.String("config", "", "path to YAML config file")
 	org := fs.String("org", "", "GitHub organization name")
-	repo := fs.String("repo", "", "single repo to audit")
+	repo := fs.String("repo", "", "single repo to audit; omit to iterate every repo in the org")
 	showIgnored := fs.Bool("show-ignored", false, "include ignored entries in output")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
-	if *cfgPath == "" || *org == "" || *repo == "" {
-		fmt.Fprintln(stderr, "audit: --config, --org, and --repo are required")
+	if *cfgPath == "" || *org == "" {
+		fmt.Fprintln(stderr, "audit: --config and --org are required")
 		return 2
 	}
 
@@ -161,12 +193,24 @@ func runAudit(args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 
-	res, err := runner.AuditRepo(context.Background(), cfg, *org, *repo, backend, stdout, *showIgnored)
+	if *repo != "" {
+		res, err := runner.AuditRepo(context.Background(), cfg, *org, *repo, backend, stdout, *showIgnored)
+		if err != nil {
+			fmt.Fprintf(stderr, "audit: %v\n", err)
+			return 1
+		}
+		if res.Drift {
+			return 1
+		}
+		return 0
+	}
+
+	res, err := runner.Audit(context.Background(), cfg, *org, backend, stdout, *showIgnored)
 	if err != nil {
 		fmt.Fprintf(stderr, "audit: %v\n", err)
 		return 1
 	}
-	if res.Drift {
+	if res.Drift || res.FailedRepos > 0 {
 		return 1
 	}
 	return 0
@@ -177,12 +221,12 @@ func runApply(args []string, stdout, stderr io.Writer) int {
 	fs.SetOutput(stderr)
 	cfgPath := fs.String("config", "", "path to YAML config file")
 	org := fs.String("org", "", "GitHub organization name")
-	repo := fs.String("repo", "", "single repo to apply")
+	repo := fs.String("repo", "", "single repo to apply; omit to iterate every repo in the org")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
-	if *cfgPath == "" || *org == "" || *repo == "" {
-		fmt.Fprintln(stderr, "apply: --config, --org, and --repo are required")
+	if *cfgPath == "" || *org == "" {
+		fmt.Fprintln(stderr, "apply: --config and --org are required")
 		return 2
 	}
 
@@ -198,12 +242,24 @@ func runApply(args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 
-	res, err := runner.ApplyRepo(context.Background(), cfg, *org, *repo, backend, stdout)
+	if *repo != "" {
+		res, err := runner.ApplyRepo(context.Background(), cfg, *org, *repo, backend, stdout)
+		if err != nil {
+			fmt.Fprintf(stderr, "apply: %v\n", err)
+			return 1
+		}
+		if res.Failed > 0 {
+			return 1
+		}
+		return 0
+	}
+
+	res, err := runner.Apply(context.Background(), cfg, *org, backend, stdout)
 	if err != nil {
 		fmt.Fprintf(stderr, "apply: %v\n", err)
 		return 1
 	}
-	if res.Failed > 0 {
+	if res.FailedEntries > 0 || res.FailedRepos > 0 {
 		return 1
 	}
 	return 0

--- a/cmd/ghsecretman/main_test.go
+++ b/cmd/ghsecretman/main_test.go
@@ -580,6 +580,110 @@ github.com:
 	}
 }
 
+func TestRun_AuditOrgWide_NoRepoFlag(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeCfg(t, dir, `
+github.com:
+  example:
+    all-repos:
+      managed:
+        vars:
+          V:
+            value: ok
+`)
+	be := &fakeBackend{
+		orgRepos: []string{"a", "b"},
+		vars:     map[string]string{"V": "ok"},
+	}
+	swapBackend(t, be, nil)
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"ghsecretman", "audit", "--config", cfgPath, "--org", "example"}, "dev", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit: got %d want 0; stderr=%q\nstdout=%q", code, stderr.String(), stdout.String())
+	}
+	for _, want := range []string{"repo: a", "repo: b", "summary: ok=2"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Errorf("stdout missing %q\n--\n%s", want, stdout.String())
+		}
+	}
+}
+
+func TestRun_ApplyOrgWide_NoRepoFlag(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeCfg(t, dir, `
+github.com:
+  example:
+    all-repos:
+      managed:
+        vars:
+          V:
+            value: ok
+`)
+	be := &fakeBackend{orgRepos: []string{"a", "b"}}
+	swapBackend(t, be, nil)
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"ghsecretman", "apply", "--config", cfgPath, "--org", "example"}, "dev", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit: got %d want 0; stderr=%q\nstdout=%q", code, stderr.String(), stdout.String())
+	}
+	if len(be.setVars) != 2 {
+		t.Errorf("expected V set on each of 2 repos; got %v", be.setVars)
+	}
+}
+
+func TestRun_EnforceOrgWide_DryRun_NoRepoFlag(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeCfg(t, dir, `
+github.com:
+  example:
+    all-repos:
+      managed:
+        vars:
+          V:
+            value: ok
+`)
+	be := &fakeBackend{orgRepos: []string{"a", "b"}, vars: map[string]string{"EXTRA": "x"}}
+	swapBackend(t, be, nil)
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"ghsecretman", "enforce", "--config", cfgPath, "--org", "example", "--dry-run"},
+		"dev", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit: got %d want 0; stderr=%q", code, stderr.String())
+	}
+	if len(be.setVars)+len(be.delVars) != 0 {
+		t.Errorf("dry-run made writes")
+	}
+	for _, want := range []string{"would-set", "would-delete", "summary: ok=2"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Errorf("stdout missing %q\n--\n%s", want, stdout.String())
+		}
+	}
+}
+
+func TestRun_AuditOrgWide_DriftReturnsOne(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeCfg(t, dir, `
+github.com:
+  example:
+    all-repos:
+      managed:
+        vars:
+          V:
+            value: yaml
+`)
+	be := &fakeBackend{orgRepos: []string{"a"}, vars: map[string]string{"V": "live"}}
+	swapBackend(t, be, nil)
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"ghsecretman", "audit", "--config", cfgPath, "--org", "example"}, "dev", &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit: got %d want 1", code)
+	}
+}
+
 type failVarBackend struct {
 	fakeBackend
 }

--- a/cmd/ghsecretman/main_test.go
+++ b/cmd/ghsecretman/main_test.go
@@ -71,6 +71,8 @@ func TestRun_NoArgs(t *testing.T) {
 }
 
 type fakeBackend struct {
+	orgRepos []string
+
 	vars       map[string]string
 	secrets    []string
 	dependabot []string
@@ -82,6 +84,10 @@ type fakeBackend struct {
 	delVars       []string
 	delSecrets    []string
 	delDependabot []string
+}
+
+func (f *fakeBackend) ListOrgRepos(_ context.Context, _ string) ([]string, error) {
+	return f.orgRepos, nil
 }
 
 func (f *fakeBackend) ListRepoVariables(_ context.Context, _, _ string) (map[string]string, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,7 +25,10 @@ func (c *Config) Org(name string) (*Org, bool) {
 
 // Org holds per-organization configuration.
 type Org struct {
-	PerRepo map[string]*Repo
+	// AllRepos, when set, holds values to fan out to every repo in the org.
+	// Per-repo entries override or shield individual repos.
+	AllRepos *Repo
+	PerRepo  map[string]*Repo
 }
 
 // Repo holds per-repo configuration.
@@ -129,13 +132,19 @@ func decodeOrg(baseDir, orgName string, n *yaml.Node) (*Org, error) {
 			}
 			for j := 0; j < len(val.Content); j += 2 {
 				repoName := val.Content[j].Value
-				repo, err := decodeRepo(baseDir, orgName, repoName, val.Content[j+1])
+				repo, err := decodeRepo(baseDir, repoName, val.Content[j+1])
 				if err != nil {
 					return nil, err
 				}
 				org.PerRepo[repoName] = repo
 			}
-		case "org", "all-repos":
+		case "all-repos":
+			repo, err := decodeRepo(baseDir, "all-repos", val)
+			if err != nil {
+				return nil, err
+			}
+			org.AllRepos = repo
+		case "org":
 			// Out of scope for this slice; reserved for future slices.
 			return nil, fmt.Errorf("org %q: scope %q not yet supported", orgName, key)
 		default:
@@ -145,7 +154,7 @@ func decodeOrg(baseDir, orgName string, n *yaml.Node) (*Org, error) {
 	return org, nil
 }
 
-func decodeRepo(baseDir, orgName, repoName string, n *yaml.Node) (*Repo, error) {
+func decodeRepo(baseDir, repoName string, n *yaml.Node) (*Repo, error) {
 	if n.Kind != yaml.MappingNode {
 		return nil, fmt.Errorf("repo %q must be a mapping", repoName)
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -306,6 +306,80 @@ github.com:
 	}
 }
 
+func TestLoad_AllRepos(t *testing.T) {
+	t.Parallel()
+
+	const yml = `
+github.com:
+  example:
+    all-repos:
+      managed:
+        vars:
+          ALL_VAR:
+            value: shared
+        secrets:
+          ALL_SEC:
+            value: s
+        dependabot:
+          ALL_DEP:
+            value: d
+      ignored:
+        vars:
+          - ALL_IG_VAR
+        secrets:
+          - ALL_IG_SEC
+        dependabot:
+          - ALL_IG_DEP
+    per-repo:
+      acme:
+        managed:
+          vars:
+            REPO_VAR:
+              value: r
+`
+	cfg, err := LoadBytes([]byte(yml), "/c/secrets.yml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	org, ok := cfg.Org("example")
+	if !ok {
+		t.Fatalf("org example missing")
+	}
+	if org.AllRepos == nil {
+		t.Fatalf("AllRepos missing")
+	}
+	if org.AllRepos.Managed.Vars["ALL_VAR"].Value != "shared" {
+		t.Errorf("ALL_VAR value: %+v", org.AllRepos.Managed.Vars["ALL_VAR"])
+	}
+	if !contains(org.AllRepos.Ignored.Vars, "ALL_IG_VAR") {
+		t.Errorf("ALL_IG_VAR not in ignored: %v", org.AllRepos.Ignored.Vars)
+	}
+	if org.PerRepo["acme"].Managed.Vars["REPO_VAR"].Value != "r" {
+		t.Errorf("REPO_VAR not parsed")
+	}
+}
+
+func TestLoad_AllReposManagedIgnoredConflict(t *testing.T) {
+	t.Parallel()
+	const yml = `
+github.com:
+  example:
+    all-repos:
+      managed:
+        vars:
+          DUP:
+            value: x
+      ignored:
+        vars:
+          - DUP
+`
+	if _, err := LoadBytes([]byte(yml), "/c/secrets.yml"); err == nil {
+		t.Fatal("expected conflict error")
+	} else if !strings.Contains(err.Error(), "DUP") {
+		t.Errorf("error should mention DUP: %v", err)
+	}
+}
+
 func TestLoad_NoSection(t *testing.T) {
 	t.Parallel()
 	cfg, err := LoadBytes([]byte("other:\n  k: v\n"), "/c/x.yml")

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -18,6 +18,8 @@ import (
 // Backend is the interface the runner consumes; satisfied by *Client and
 // by test fakes.
 type Backend interface {
+	ListOrgRepos(ctx context.Context, org string) ([]string, error)
+
 	ListRepoVariables(ctx context.Context, owner, repo string) (map[string]string, error)
 	ListRepoSecrets(ctx context.Context, owner, repo string) ([]string, error)
 	ListRepoDependabotSecrets(ctx context.Context, owner, repo string) ([]string, error)
@@ -56,6 +58,31 @@ func NewClientFromEnv() (*Client, error) {
 // that need to point at httptest.
 func NewClientFromGoGithub(gh *gogithub.Client) *Client {
 	return &Client{gh: gh}
+}
+
+// ListOrgRepos returns the names of every repository in the org. Pages
+// through the list until exhausted.
+func (c *Client) ListOrgRepos(ctx context.Context, org string) ([]string, error) {
+	opts := &gogithub.RepositoryListByOrgOptions{
+		ListOptions: gogithub.ListOptions{PerPage: 100},
+	}
+	var names []string
+	for {
+		repos, resp, err := c.gh.Repositories.ListByOrg(ctx, org, opts)
+		if err != nil {
+			return nil, fmt.Errorf("list org repos: %w", err)
+		}
+		for _, r := range repos {
+			if r != nil && r.Name != nil {
+				names = append(names, *r.Name)
+			}
+		}
+		if resp == nil || resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+	return names, nil
 }
 
 // ListRepoVariables returns repo Actions variables as a name → value map.

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -22,6 +22,76 @@ import (
 	"golang.org/x/crypto/nacl/box"
 )
 
+func TestClient_ListOrgRepos(t *testing.T) {
+	t.Parallel()
+	srv, c := newTestClient(t, map[string]string{
+		"/orgs/example/repos": `[{"name":"alpha"},{"name":"beta"}]`,
+	})
+	defer srv.Close()
+
+	got, err := c.ListOrgRepos(context.Background(), "example")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	sort.Strings(got)
+	want := []string{"alpha", "beta"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("got %v want %v", got, want)
+	}
+}
+
+func TestClient_ListOrgRepos_Pagination(t *testing.T) {
+	t.Parallel()
+	var (
+		mu       sync.Mutex
+		seenPage []string
+	)
+	var srvURL string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		page := r.URL.Query().Get("page")
+		seenPage = append(seenPage, page)
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		switch page {
+		case "", "1":
+			w.Header().Set("Link", `<`+srvURL+r.URL.Path+`?page=2>; rel="next"`)
+			fmt.Fprint(w, `[{"name":"alpha"}]`)
+		case "2":
+			fmt.Fprint(w, `[{"name":"beta"}]`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	srvURL = srv.URL
+	defer srv.Close()
+	c := newClientPointingAt(t, srv.URL)
+
+	got, err := c.ListOrgRepos(context.Background(), "example")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	sort.Strings(got)
+	if strings.Join(got, ",") != "alpha,beta" {
+		t.Fatalf("got %v", got)
+	}
+	if len(seenPage) < 2 {
+		t.Errorf("expected pagination across at least 2 pages; saw %v", seenPage)
+	}
+}
+
+func TestClient_ListOrgRepos_Error(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"nope"}`, http.StatusForbidden)
+	}))
+	defer srv.Close()
+	c := newClientPointingAt(t, srv.URL)
+	if _, err := c.ListOrgRepos(context.Background(), "example"); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
 func TestClient_ListRepoVariables(t *testing.T) {
 	t.Parallel()
 	srv, c := newTestClient(t, map[string]string{

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -40,6 +40,11 @@ type Intent struct {
 	Name   string
 	Action Action
 	Entry  *config.Entry
+
+	// OverridesAllRepos is true when this intent's name was also present in
+	// all-repos.managed and the per-repo entry took precedence. Reserved for
+	// audit-side override reporting; runtime behavior is unaffected.
+	OverridesAllRepos bool
 }
 
 // ForRepo returns intents for every managed entry on the repo plus a

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -108,48 +108,14 @@ func ForRepoCascade(repoName string, allRepos, perRepo *config.Repo) []Intent {
 	return out
 }
 
+type cascadeWinner struct {
+	action            Action
+	entry             *config.Entry
+	overridesAllRepos bool
+}
+
 func appendCascadeKind(out []Intent, repo string, kind Kind, allRepos, perRepo *config.Repo) []Intent {
-	prMan, prIg := managedFor(perRepo, kind), ignoredFor(perRepo, kind)
-	arMan, arIg := managedFor(allRepos, kind), ignoredFor(allRepos, kind)
-
-	prIgSet := stringSet(prIg)
-
-	type winner struct {
-		action  Action
-		entry   *config.Entry
-		overrid bool
-	}
-	resolved := map[string]winner{}
-
-	for n, e := range prMan {
-		w := winner{action: ActionManaged, entry: e}
-		if _, ok := arMan[n]; ok {
-			w.overrid = true
-		}
-		resolved[n] = w
-	}
-	for _, n := range prIg {
-		if _, ok := resolved[n]; ok {
-			continue
-		}
-		resolved[n] = winner{action: ActionIgnored}
-	}
-	for n, e := range arMan {
-		if _, ok := resolved[n]; ok {
-			continue
-		}
-		if _, shielded := prIgSet[n]; shielded {
-			continue
-		}
-		resolved[n] = winner{action: ActionManaged, entry: e}
-	}
-	for _, n := range arIg {
-		if _, ok := resolved[n]; ok {
-			continue
-		}
-		resolved[n] = winner{action: ActionIgnored}
-	}
-
+	resolved := resolveCascade(allRepos, perRepo, kind)
 	managedNames := make([]string, 0)
 	ignoredNames := make([]string, 0)
 	for n, w := range resolved {
@@ -168,7 +134,7 @@ func appendCascadeKind(out []Intent, repo string, kind Kind, allRepos, perRepo *
 			Repo: repo, Kind: kind, Name: n,
 			Action:            ActionManaged,
 			Entry:             w.entry,
-			OverridesAllRepos: w.overrid,
+			OverridesAllRepos: w.overridesAllRepos,
 		})
 	}
 	for _, n := range ignoredNames {
@@ -178,6 +144,43 @@ func appendCascadeKind(out []Intent, repo string, kind Kind, allRepos, perRepo *
 		})
 	}
 	return out
+}
+
+func resolveCascade(allRepos, perRepo *config.Repo, kind Kind) map[string]cascadeWinner {
+	prMan, prIg := managedFor(perRepo, kind), ignoredFor(perRepo, kind)
+	arMan, arIg := managedFor(allRepos, kind), ignoredFor(allRepos, kind)
+	prIgSet := stringSet(prIg)
+	resolved := map[string]cascadeWinner{}
+
+	for n, e := range prMan {
+		w := cascadeWinner{action: ActionManaged, entry: e}
+		if _, ok := arMan[n]; ok {
+			w.overridesAllRepos = true
+		}
+		resolved[n] = w
+	}
+	for _, n := range prIg {
+		if _, ok := resolved[n]; ok {
+			continue
+		}
+		resolved[n] = cascadeWinner{action: ActionIgnored}
+	}
+	for n, e := range arMan {
+		if _, ok := resolved[n]; ok {
+			continue
+		}
+		if _, shielded := prIgSet[n]; shielded {
+			continue
+		}
+		resolved[n] = cascadeWinner{action: ActionManaged, entry: e}
+	}
+	for _, n := range arIg {
+		if _, ok := resolved[n]; ok {
+			continue
+		}
+		resolved[n] = cascadeWinner{action: ActionIgnored}
+	}
+	return resolved
 }
 
 func managedFor(r *config.Repo, kind Kind) map[string]*config.Entry {

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -91,6 +91,157 @@ func appendKind(out []Intent, repo string, kind Kind, m map[string]*config.Entry
 	return out
 }
 
+// ForRepoCascade returns intents for one repo after applying the
+// per-repo > all-repos precedence rules.
+//
+// Rules (per kind, per name):
+//   - In per-repo.managed → managed (per-repo entry).
+//     Marked OverridesAllRepos when the same name was also in all-repos.managed.
+//   - In per-repo.ignored → ignored.
+//   - In all-repos.managed (and not above) → managed (all-repos entry).
+//   - In all-repos.ignored (and not above) → ignored.
+func ForRepoCascade(repoName string, allRepos, perRepo *config.Repo) []Intent {
+	out := make([]Intent, 0)
+	out = appendCascadeKind(out, repoName, KindVar, allRepos, perRepo)
+	out = appendCascadeKind(out, repoName, KindSecret, allRepos, perRepo)
+	out = appendCascadeKind(out, repoName, KindDependabot, allRepos, perRepo)
+	return out
+}
+
+func appendCascadeKind(out []Intent, repo string, kind Kind, allRepos, perRepo *config.Repo) []Intent {
+	prMan, prIg := managedFor(perRepo, kind), ignoredFor(perRepo, kind)
+	arMan, arIg := managedFor(allRepos, kind), ignoredFor(allRepos, kind)
+
+	prIgSet := stringSet(prIg)
+
+	type winner struct {
+		action  Action
+		entry   *config.Entry
+		overrid bool
+	}
+	resolved := map[string]winner{}
+
+	for n, e := range prMan {
+		w := winner{action: ActionManaged, entry: e}
+		if _, ok := arMan[n]; ok {
+			w.overrid = true
+		}
+		resolved[n] = w
+	}
+	for _, n := range prIg {
+		if _, ok := resolved[n]; ok {
+			continue
+		}
+		resolved[n] = winner{action: ActionIgnored}
+	}
+	for n, e := range arMan {
+		if _, ok := resolved[n]; ok {
+			continue
+		}
+		if _, shielded := prIgSet[n]; shielded {
+			continue
+		}
+		resolved[n] = winner{action: ActionManaged, entry: e}
+	}
+	for _, n := range arIg {
+		if _, ok := resolved[n]; ok {
+			continue
+		}
+		resolved[n] = winner{action: ActionIgnored}
+	}
+
+	managedNames := make([]string, 0)
+	ignoredNames := make([]string, 0)
+	for n, w := range resolved {
+		if w.action == ActionManaged {
+			managedNames = append(managedNames, n)
+		} else {
+			ignoredNames = append(ignoredNames, n)
+		}
+	}
+	sort.Strings(managedNames)
+	sort.Strings(ignoredNames)
+
+	for _, n := range managedNames {
+		w := resolved[n]
+		out = append(out, Intent{
+			Repo: repo, Kind: kind, Name: n,
+			Action:            ActionManaged,
+			Entry:             w.entry,
+			OverridesAllRepos: w.overrid,
+		})
+	}
+	for _, n := range ignoredNames {
+		out = append(out, Intent{
+			Repo: repo, Kind: kind, Name: n,
+			Action: ActionIgnored,
+		})
+	}
+	return out
+}
+
+func managedFor(r *config.Repo, kind Kind) map[string]*config.Entry {
+	if r == nil {
+		return nil
+	}
+	switch kind {
+	case KindVar:
+		return r.Managed.Vars
+	case KindSecret:
+		return r.Managed.Secrets
+	case KindDependabot:
+		return r.Managed.Dependabot
+	}
+	return nil
+}
+
+func ignoredFor(r *config.Repo, kind Kind) []string {
+	if r == nil {
+		return nil
+	}
+	switch kind {
+	case KindVar:
+		return r.Ignored.Vars
+	case KindSecret:
+		return r.Ignored.Secrets
+	case KindDependabot:
+		return r.Ignored.Dependabot
+	}
+	return nil
+}
+
+func stringSet(ss []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(ss))
+	for _, s := range ss {
+		out[s] = struct{}{}
+	}
+	return out
+}
+
+// EffectiveIgnored returns the cascaded ignored list at a single repo.
+//
+// Useful for downstream code (diff) that needs an ignored set for marking
+// extras. A name is effectively ignored when it ends up in an ActionIgnored
+// intent under ForRepoCascade.
+func EffectiveIgnored(allRepos, perRepo *config.Repo) config.Ignored {
+	intents := ForRepoCascade("", allRepos, perRepo)
+	var out config.Ignored
+	for _, in := range intents {
+		if in.Action != ActionIgnored {
+			continue
+		}
+		switch in.Kind {
+		case KindVar:
+			out.Vars = append(out.Vars, in.Name)
+		case KindSecret:
+			out.Secrets = append(out.Secrets, in.Name)
+		case KindDependabot:
+			out.Dependabot = append(out.Dependabot, in.Name)
+		}
+	}
+	return out
+}
+
 // IsIgnored reports whether name appears in the repo's ignored list for kind.
 func IsIgnored(r *config.Repo, kind Kind, name string) bool {
 	if r == nil {

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -67,6 +67,234 @@ func TestForRepo(t *testing.T) {
 	}
 }
 
+func TestForRepoCascade_Matrix(t *testing.T) {
+	t.Parallel()
+
+	type want struct {
+		action            Action
+		fromAllRepos      bool // true → entry should equal all-repos's entry
+		overridesAllRepos bool
+	}
+
+	tests := []struct {
+		name      string
+		allMan    []string
+		allIg     []string
+		repoMan   []string
+		repoIg    []string
+		wantNames map[string]want // Name -> expectation; absent means absent
+	}{
+		{
+			name:      "only all-repos.managed",
+			allMan:    []string{"X"},
+			wantNames: map[string]want{"X": {action: ActionManaged, fromAllRepos: true}},
+		},
+		{
+			name:      "only all-repos.ignored",
+			allIg:     []string{"X"},
+			wantNames: map[string]want{"X": {action: ActionIgnored}},
+		},
+		{
+			name:      "only per-repo.managed",
+			repoMan:   []string{"X"},
+			wantNames: map[string]want{"X": {action: ActionManaged}},
+		},
+		{
+			name:      "only per-repo.ignored",
+			repoIg:    []string{"X"},
+			wantNames: map[string]want{"X": {action: ActionIgnored}},
+		},
+		{
+			name:    "per-repo.managed overrides all-repos.managed",
+			allMan:  []string{"X"},
+			repoMan: []string{"X"},
+			wantNames: map[string]want{
+				"X": {action: ActionManaged, overridesAllRepos: true},
+			},
+		},
+		{
+			name:      "per-repo.ignored shields all-repos.managed",
+			allMan:    []string{"X"},
+			repoIg:    []string{"X"},
+			wantNames: map[string]want{"X": {action: ActionIgnored}},
+		},
+		{
+			name:      "per-repo.managed overrides all-repos.ignored",
+			allIg:     []string{"X"},
+			repoMan:   []string{"X"},
+			wantNames: map[string]want{"X": {action: ActionManaged}},
+		},
+		{
+			name:      "per-repo.ignored absorbs all-repos.ignored",
+			allIg:     []string{"X"},
+			repoIg:    []string{"X"},
+			wantNames: map[string]want{"X": {action: ActionIgnored}},
+		},
+		{
+			name:    "disjoint names from each layer all surface",
+			allMan:  []string{"A_M"},
+			allIg:   []string{"A_I"},
+			repoMan: []string{"R_M"},
+			repoIg:  []string{"R_I"},
+			wantNames: map[string]want{
+				"A_M": {action: ActionManaged, fromAllRepos: true},
+				"A_I": {action: ActionIgnored},
+				"R_M": {action: ActionManaged},
+				"R_I": {action: ActionIgnored},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			allRepos := buildRepo(tc.allMan, tc.allIg, "all")
+			perRepo := buildRepo(tc.repoMan, tc.repoIg, "repo")
+
+			intents := ForRepoCascade("acme", allRepos, perRepo)
+			byName := map[string]Intent{}
+			for _, in := range intents {
+				if in.Kind != KindVar {
+					continue
+				}
+				byName[in.Name] = in
+			}
+			if len(byName) != len(tc.wantNames) {
+				t.Fatalf("intent count: got %d want %d (intents=%+v)",
+					len(byName), len(tc.wantNames), intents)
+			}
+			for name, w := range tc.wantNames {
+				got, ok := byName[name]
+				if !ok {
+					t.Fatalf("intent for %s missing; got=%+v", name, byName)
+				}
+				if got.Action != w.action {
+					t.Errorf("%s action: got %s want %s", name, got.Action, w.action)
+				}
+				if got.OverridesAllRepos != w.overridesAllRepos {
+					t.Errorf("%s overrides: got %v want %v",
+						name, got.OverridesAllRepos, w.overridesAllRepos)
+				}
+				if w.action == ActionManaged {
+					if got.Entry == nil {
+						t.Errorf("%s: managed intent should have entry", name)
+					} else {
+						wantPrefix := "repo-"
+						if w.fromAllRepos {
+							wantPrefix = "all-"
+						}
+						wantVal := wantPrefix + name + "-val"
+						if got.Entry.Value != wantVal {
+							t.Errorf("%s: entry value got %q want %q",
+								name, got.Entry.Value, wantVal)
+						}
+					}
+				}
+				if w.action == ActionIgnored && got.Entry != nil {
+					t.Errorf("%s: ignored intent must have nil entry", name)
+				}
+			}
+		})
+	}
+}
+
+// TestForRepoCascade_PerKindIsolation asserts that the same name in different
+// kinds doesn't interfere across kinds — the cascade is per (kind, name).
+func TestForRepoCascade_PerKindIsolation(t *testing.T) {
+	t.Parallel()
+	allRepos := &config.Repo{
+		Managed: config.Managed{
+			Vars:    map[string]*config.Entry{"X": {HasValue: true, Value: "vars-all"}},
+			Secrets: map[string]*config.Entry{"X": {HasValue: true, Value: "sec-all"}},
+		},
+	}
+	perRepo := &config.Repo{
+		Ignored: config.Ignored{Vars: []string{"X"}},
+	}
+	intents := ForRepoCascade("acme", allRepos, perRepo)
+	var sawIgnoredVar, sawManagedSecret bool
+	for _, in := range intents {
+		if in.Kind == KindVar && in.Name == "X" && in.Action == ActionIgnored {
+			sawIgnoredVar = true
+		}
+		if in.Kind == KindSecret && in.Name == "X" && in.Action == ActionManaged {
+			sawManagedSecret = true
+			if in.Entry == nil || in.Entry.Value != "sec-all" {
+				t.Errorf("secret X should resolve to all-repos entry; got %+v", in.Entry)
+			}
+		}
+	}
+	if !sawIgnoredVar {
+		t.Errorf("vars/X should be ignored (per-repo.Ignored shields all-repos.managed)")
+	}
+	if !sawManagedSecret {
+		t.Errorf("secrets/X should be managed from all-repos (per-repo doesn't reference it)")
+	}
+}
+
+func TestForRepoCascade_NilArguments(t *testing.T) {
+	t.Parallel()
+	if intents := ForRepoCascade("acme", nil, nil); len(intents) != 0 {
+		t.Errorf("expected no intents from nil-nil; got %d", len(intents))
+	}
+}
+
+func TestEffectiveIgnored(t *testing.T) {
+	t.Parallel()
+	allRepos := &config.Repo{
+		Ignored: config.Ignored{
+			Vars:       []string{"AV"},
+			Secrets:    []string{"AS"},
+			Dependabot: []string{"AD"},
+		},
+		Managed: config.Managed{
+			Vars: map[string]*config.Entry{"OV": {HasValue: true, Value: "x"}},
+		},
+	}
+	perRepo := &config.Repo{
+		Ignored: config.Ignored{Vars: []string{"PV"}},
+		Managed: config.Managed{
+			// per-repo.managed must not appear as ignored even if all-repos says so.
+			Vars: map[string]*config.Entry{"AV": {HasValue: true, Value: "y"}},
+		},
+	}
+	got := EffectiveIgnored(allRepos, perRepo)
+	if !sortedEqual(got.Vars, []string{"PV"}) {
+		t.Errorf("vars ignored: got %v want [PV]", got.Vars)
+	}
+	if !sortedEqual(got.Secrets, []string{"AS"}) {
+		t.Errorf("secrets ignored: got %v want [AS]", got.Secrets)
+	}
+	if !sortedEqual(got.Dependabot, []string{"AD"}) {
+		t.Errorf("dependabot ignored: got %v want [AD]", got.Dependabot)
+	}
+}
+
+func buildRepo(managed, ignored []string, suffix string) *config.Repo {
+	if managed == nil && ignored == nil {
+		return nil
+	}
+	r := &config.Repo{}
+	if len(managed) > 0 {
+		r.Managed.Vars = map[string]*config.Entry{}
+		for _, n := range managed {
+			r.Managed.Vars[n] = &config.Entry{HasValue: true, Value: suffix + "-" + n + "-val"}
+		}
+	}
+	if len(ignored) > 0 {
+		r.Ignored.Vars = append([]string(nil), ignored...)
+	}
+	return r
+}
+
+func sortedEqual(a, b []string) bool {
+	aa := append([]string(nil), a...)
+	bb := append([]string(nil), b...)
+	sort.Strings(aa)
+	sort.Strings(bb)
+	return equal(aa, bb)
+}
+
 func TestForRepo_EmptyRepo(t *testing.T) {
 	t.Parallel()
 	intents := ForRepo("acme", &config.Repo{})

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -30,17 +30,16 @@ type Result struct {
 
 // AuditRepo runs an audit against a single repo and writes a labeled
 // stanza to out. showIgnored controls whether ignored entries appear.
+//
+// The repo is resolved via the per-repo > all-repos cascade. A repo with
+// no per-repo block is still valid as long as the org defines all-repos.
 func AuditRepo(ctx context.Context, cfg *config.Config, org, repo string, backend gh.Backend, out io.Writer, showIgnored bool) (Result, error) {
-	o, ok := cfg.Org(org)
-	if !ok {
-		return Result{}, fmt.Errorf("org %q not found in config", org)
-	}
-	r, ok := o.PerRepo[repo]
-	if !ok {
-		return Result{}, fmt.Errorf("repo %q not found under org %q", repo, org)
+	o, perRepo, err := lookupTarget(cfg, org, repo)
+	if err != nil {
+		return Result{}, err
 	}
 
-	intents := plan.ForRepo(repo, r)
+	intents := plan.ForRepoCascade(repo, o.AllRepos, perRepo)
 
 	desiredVars, err := resolveVars(intents)
 	if err != nil {
@@ -52,10 +51,23 @@ func AuditRepo(ctx context.Context, cfg *config.Config, org, repo string, backen
 		return Result{}, err
 	}
 
-	entries := diff.Compute(repo, intents, desiredVars, live, r.Ignored)
+	effIgnored := plan.EffectiveIgnored(o.AllRepos, perRepo)
+	entries := diff.Compute(repo, intents, desiredVars, live, effIgnored)
 	writeStanza(out, org, repo, entries, showIgnored)
 
 	return Result{Drift: diff.HasDrift(entries)}, nil
+}
+
+func lookupTarget(cfg *config.Config, org, repo string) (*config.Org, *config.Repo, error) {
+	o, ok := cfg.Org(org)
+	if !ok {
+		return nil, nil, fmt.Errorf("org %q not found in config", org)
+	}
+	perRepo := o.PerRepo[repo]
+	if perRepo == nil && o.AllRepos == nil {
+		return nil, nil, fmt.Errorf("repo %q not found under org %q", repo, org)
+	}
+	return o, perRepo, nil
 }
 
 func resolveVars(intents []plan.Intent) (map[string]string, error) {
@@ -113,16 +125,12 @@ func writeStanza(out io.Writer, org, repo string, entries []diff.Entry, showIgno
 // per call (only when the corresponding section has at least one entry)
 // and reused across all set calls.
 func ApplyRepo(ctx context.Context, cfg *config.Config, org, repo string, backend gh.Backend, out io.Writer) (Result, error) {
-	o, ok := cfg.Org(org)
-	if !ok {
-		return Result{}, fmt.Errorf("org %q not found in config", org)
-	}
-	r, ok := o.PerRepo[repo]
-	if !ok {
-		return Result{}, fmt.Errorf("repo %q not found under org %q", repo, org)
+	o, perRepo, err := lookupTarget(cfg, org, repo)
+	if err != nil {
+		return Result{}, err
 	}
 
-	intents := plan.ForRepo(repo, r)
+	intents := plan.ForRepoCascade(repo, o.AllRepos, perRepo)
 	resolved, err := resolveAll(intents)
 	if err != nil {
 		return Result{}, err
@@ -233,16 +241,12 @@ type EnforceOptions struct {
 // The TTY/--yes confirmation contract is owned by the CLI layer; by the
 // time EnforceRepo is called, the caller has already decided to proceed.
 func EnforceRepo(ctx context.Context, cfg *config.Config, org, repo string, backend gh.Backend, out io.Writer, opts EnforceOptions) (Result, error) {
-	o, ok := cfg.Org(org)
-	if !ok {
-		return Result{}, fmt.Errorf("org %q not found in config", org)
-	}
-	r, ok := o.PerRepo[repo]
-	if !ok {
-		return Result{}, fmt.Errorf("repo %q not found under org %q", repo, org)
+	o, perRepo, err := lookupTarget(cfg, org, repo)
+	if err != nil {
+		return Result{}, err
 	}
 
-	intents := plan.ForRepo(repo, r)
+	intents := plan.ForRepoCascade(repo, o.AllRepos, perRepo)
 
 	resolved, err := resolveForEnforce(intents, opts.DryRun)
 	if err != nil {
@@ -253,7 +257,8 @@ func EnforceRepo(ctx context.Context, cfg *config.Config, org, repo string, back
 	if err != nil {
 		return Result{}, err
 	}
-	entries := diff.Compute(repo, intents, desiredVarsFromResolved(intents, resolved), live, r.Ignored)
+	effIgnored := plan.EffectiveIgnored(o.AllRepos, perRepo)
+	entries := diff.Compute(repo, intents, desiredVarsFromResolved(intents, resolved), live, effIgnored)
 
 	if !opts.DryRun && opts.Confirm != nil && !opts.Confirm(extraKindNames(entries)) {
 		return Result{}, nil
@@ -358,6 +363,119 @@ func deleteOne(ctx context.Context, backend gh.Backend, org, repo string, kind p
 		return backend.DeleteRepoDependabotSecret(ctx, org, repo, name)
 	}
 	return fmt.Errorf("unknown kind %q", kind)
+}
+
+// OrgResult aggregates per-repo outcomes from an org-wide run.
+type OrgResult struct {
+	// Drift is true if any repo's audit produced drift.
+	Drift bool
+	// FailedEntries is the cross-repo sum of per-entry failures (apply/enforce).
+	FailedEntries int
+	// OkRepos is the count of repos that completed without a per-repo error.
+	OkRepos int
+	// FailedRepos is the count of repos whose top-level call returned an error.
+	FailedRepos int
+}
+
+// targetRepos returns the org repos that will be processed: every name from
+// ListOrgRepos for which either all-repos applies or a per-repo entry exists.
+//
+// Repos not addressed by config are skipped silently — there is nothing to
+// audit, apply, or enforce on them.
+func targetRepos(ctx context.Context, backend gh.Backend, o *config.Org, org string) ([]string, error) {
+	all, err := backend.ListOrgRepos(ctx, org)
+	if err != nil {
+		return nil, fmt.Errorf("list org repos: %w", err)
+	}
+	out := make([]string, 0, len(all))
+	for _, r := range all {
+		if o.AllRepos != nil || o.PerRepo[r] != nil {
+			out = append(out, r)
+		}
+	}
+	return out, nil
+}
+
+// Audit runs an audit across every repo in the org. Per-repo errors are
+// reported and the run continues. The final summary line counts ok and
+// failed repos.
+func Audit(ctx context.Context, cfg *config.Config, org string, backend gh.Backend, out io.Writer, showIgnored bool) (OrgResult, error) {
+	o, ok := cfg.Org(org)
+	if !ok {
+		return OrgResult{}, fmt.Errorf("org %q not found in config", org)
+	}
+	repos, err := targetRepos(ctx, backend, o, org)
+	if err != nil {
+		return OrgResult{}, err
+	}
+	var res OrgResult
+	for _, repo := range repos {
+		r, err := AuditRepo(ctx, cfg, org, repo, backend, out, showIgnored)
+		if err != nil {
+			fmt.Fprintf(out, "repo: %s\n  ERROR: %v\n", repo, err)
+			res.FailedRepos++
+			continue
+		}
+		if r.Drift {
+			res.Drift = true
+		}
+		res.OkRepos++
+	}
+	fmt.Fprintf(out, "summary: ok=%d failed=%d\n", res.OkRepos, res.FailedRepos)
+	return res, nil
+}
+
+// Apply runs apply across every repo in the org. Per-repo errors are
+// reported and the run continues; per-entry write failures are summed
+// into FailedEntries.
+func Apply(ctx context.Context, cfg *config.Config, org string, backend gh.Backend, out io.Writer) (OrgResult, error) {
+	o, ok := cfg.Org(org)
+	if !ok {
+		return OrgResult{}, fmt.Errorf("org %q not found in config", org)
+	}
+	repos, err := targetRepos(ctx, backend, o, org)
+	if err != nil {
+		return OrgResult{}, err
+	}
+	var res OrgResult
+	for _, repo := range repos {
+		r, err := ApplyRepo(ctx, cfg, org, repo, backend, out)
+		if err != nil {
+			fmt.Fprintf(out, "repo: %s\n  ERROR: %v\n", repo, err)
+			res.FailedRepos++
+			continue
+		}
+		res.FailedEntries += r.Failed
+		res.OkRepos++
+	}
+	fmt.Fprintf(out, "summary: ok=%d failed=%d\n", res.OkRepos, res.FailedRepos)
+	return res, nil
+}
+
+// Enforce runs enforce across every repo in the org. The provided opts
+// are forwarded to each EnforceRepo call.
+func Enforce(ctx context.Context, cfg *config.Config, org string, backend gh.Backend, out io.Writer, opts EnforceOptions) (OrgResult, error) {
+	o, ok := cfg.Org(org)
+	if !ok {
+		return OrgResult{}, fmt.Errorf("org %q not found in config", org)
+	}
+	repos, err := targetRepos(ctx, backend, o, org)
+	if err != nil {
+		return OrgResult{}, err
+	}
+	var res OrgResult
+	for _, repo := range repos {
+		r, err := EnforceRepo(ctx, cfg, org, repo, backend, out, opts)
+		if err != nil {
+			fmt.Fprintf(out, "repo: %s\n  ERROR: %v\n", repo, err)
+			res.FailedRepos++
+			continue
+		}
+		res.FailedEntries += r.Failed
+		res.OkRepos++
+	}
+	fmt.Fprintf(out, "summary: ok=%d failed=%d\n", res.OkRepos, res.FailedRepos)
+	return res, nil
 }
 
 // writeFile is a thin wrapper used by tests to materialize fixture YAML.

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -1274,6 +1274,421 @@ github.com:
 	}
 }
 
+func TestAudit_IteratesEveryOrgRepo(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "secrets.yml")
+	if err := writeFile(cfgPath, []byte(`
+github.com:
+  example:
+    all-repos:
+      managed:
+        vars:
+          ALL_VAR:
+            value: ok
+`)); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	be := &fakeBackend{
+		orgRepos: []string{"acme", "beta"},
+		vars:     map[string]string{"ALL_VAR": "ok"},
+	}
+	var out bytes.Buffer
+	res, err := Audit(context.Background(), cfg, "example", be, &out, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Drift {
+		t.Errorf("expected no drift; got:\n%s", out.String())
+	}
+	if res.OkRepos != 2 || res.FailedRepos != 0 {
+		t.Errorf("repo counts: ok=%d failed=%d (want ok=2 failed=0)",
+			res.OkRepos, res.FailedRepos)
+	}
+	s := out.String()
+	for _, want := range []string{"repo: acme", "repo: beta", "summary: ok=2 failed=0"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("output missing %q\n--\n%s", want, s)
+		}
+	}
+}
+
+func TestAudit_SkipsReposNotInConfig(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "secrets.yml")
+	if err := writeFile(cfgPath, []byte(`
+github.com:
+  example:
+    per-repo:
+      acme:
+        managed:
+          vars:
+            V:
+              value: ok
+`)); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	be := &fakeBackend{
+		orgRepos: []string{"acme", "unrelated"},
+		vars:     map[string]string{"V": "ok"},
+	}
+	var out bytes.Buffer
+	res, err := Audit(context.Background(), cfg, "example", be, &out, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.OkRepos != 1 {
+		t.Errorf("ok repos: got %d want 1 (unrelated should be skipped)", res.OkRepos)
+	}
+	if strings.Contains(out.String(), "repo: unrelated") {
+		t.Errorf("unrelated repo should not appear in output:\n%s", out.String())
+	}
+}
+
+func TestAudit_PerRepoErrorContinues(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "secrets.yml")
+	if err := writeFile(cfgPath, []byte(`
+github.com:
+  example:
+    all-repos:
+      managed:
+        vars:
+          V:
+            value: ok
+`)); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Backend errors on repo list calls; every repo errors uniformly.
+	be := &fakeBackend{
+		orgRepos: []string{"a", "b"},
+		err:      errors.New("boom"),
+	}
+	var out bytes.Buffer
+	res, err := Audit(context.Background(), cfg, "example", be, &out, false)
+	if err != nil {
+		t.Fatalf("Audit should continue on per-repo error, not return one: %v", err)
+	}
+	if res.FailedRepos != 2 || res.OkRepos != 0 {
+		t.Errorf("got ok=%d failed=%d; want ok=0 failed=2", res.OkRepos, res.FailedRepos)
+	}
+	s := out.String()
+	if !strings.Contains(s, "ERROR: ") {
+		t.Errorf("expected ERROR line in output:\n%s", s)
+	}
+	if !strings.Contains(s, "summary: ok=0 failed=2") {
+		t.Errorf("expected summary line: %q", s)
+	}
+}
+
+func TestAudit_ListOrgReposError(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "secrets.yml")
+	if err := writeFile(cfgPath, []byte(`
+github.com:
+  example:
+    all-repos:
+      managed: {}
+`)); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	be := &fakeBackend{orgReposErr: errors.New("forbidden")}
+	if _, err := Audit(context.Background(), cfg, "example", be, &bytes.Buffer{}, false); err == nil {
+		t.Fatal("expected error when ListOrgRepos fails")
+	}
+}
+
+func TestAudit_UnknownOrg(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{Orgs: map[string]*config.Org{}}
+	if _, err := Audit(context.Background(), cfg, "missing", &fakeBackend{}, &bytes.Buffer{}, false); err == nil {
+		t.Fatal("expected error for unknown org")
+	}
+}
+
+func TestApply_IteratesAndAppliesCascade(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "secrets.yml")
+	if err := writeFile(cfgPath, []byte(`
+github.com:
+  example:
+    all-repos:
+      managed:
+        vars:
+          ALL_VAR:
+            value: shared
+    per-repo:
+      acme:
+        managed:
+          vars:
+            ALL_VAR:
+              value: acme-override
+`)); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	be := &fakeBackend{orgRepos: []string{"acme", "beta"}}
+	var out bytes.Buffer
+	res, err := Apply(context.Background(), cfg, "example", be, &out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.OkRepos != 2 {
+		t.Errorf("ok repos: %d", res.OkRepos)
+	}
+	wantValues := map[string]string{
+		"acme": "acme-override",
+		"beta": "shared",
+	}
+	got := map[string]string{}
+	for _, c := range be.setVarCalls {
+		got[c.repo] = c.value
+	}
+	for r, v := range wantValues {
+		if got[r] != v {
+			t.Errorf("repo %s: got %q want %q (per-repo > all-repos)", r, got[r], v)
+		}
+	}
+}
+
+func TestApply_UnknownOrg(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{Orgs: map[string]*config.Org{}}
+	if _, err := Apply(context.Background(), cfg, "missing", &fakeBackend{}, &bytes.Buffer{}); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestApply_ListOrgReposError(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{Orgs: map[string]*config.Org{
+		"example": {AllRepos: &config.Repo{}},
+	}}
+	be := &fakeBackend{orgReposErr: errors.New("boom")}
+	if _, err := Apply(context.Background(), cfg, "example", be, &bytes.Buffer{}); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestEnforce_IteratesDryRun(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "secrets.yml")
+	if err := writeFile(cfgPath, []byte(`
+github.com:
+  example:
+    all-repos:
+      managed:
+        vars:
+          KEEP:
+            value: ok
+`)); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	be := &fakeBackend{
+		orgRepos: []string{"acme", "beta"},
+		vars:     map[string]string{"EXTRA": "x"},
+	}
+	var out bytes.Buffer
+	if _, err := Enforce(context.Background(), cfg, "example", be, &out, EnforceOptions{DryRun: true}); err != nil {
+		t.Fatal(err)
+	}
+	if len(be.setVarCalls)+len(be.delVarCalls) != 0 {
+		t.Errorf("dry-run made writes: sets=%v dels=%v", be.setVarCalls, be.delVarCalls)
+	}
+	s := out.String()
+	for _, want := range []string{"repo: acme", "repo: beta", "would-set", "would-delete"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("output missing %q\n--\n%s", want, s)
+		}
+	}
+}
+
+func TestEnforce_UnknownOrg(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{Orgs: map[string]*config.Org{}}
+	if _, err := Enforce(context.Background(), cfg, "missing", &fakeBackend{}, &bytes.Buffer{}, EnforceOptions{}); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestEnforce_ListOrgReposError(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{Orgs: map[string]*config.Org{
+		"example": {AllRepos: &config.Repo{}},
+	}}
+	be := &fakeBackend{orgReposErr: errors.New("boom")}
+	if _, err := Enforce(context.Background(), cfg, "example", be, &bytes.Buffer{}, EnforceOptions{}); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+// TestAuditRepo_AllReposOnly asserts that when a repo has no per-repo entry
+// but the org defines all-repos, the per-repo audit still proceeds via
+// cascade.
+func TestAuditRepo_AllReposOnly(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "secrets.yml")
+	if err := writeFile(cfgPath, []byte(`
+github.com:
+  example:
+    all-repos:
+      managed:
+        vars:
+          V:
+            value: shared
+`)); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	be := &fakeBackend{vars: map[string]string{"V": "shared"}}
+	res, err := AuditRepo(context.Background(), cfg, "example", "any-repo", be, &bytes.Buffer{}, false)
+	if err != nil {
+		t.Fatalf("repo with no per-repo entry should still audit when all-repos exists: %v", err)
+	}
+	if res.Drift {
+		t.Errorf("expected no drift")
+	}
+}
+
+// TestApplyRepo_PerRepoOverridesAllRepos asserts that the cascade path
+// honors per-repo > all-repos at the apply layer.
+func TestApplyRepo_PerRepoOverridesAllRepos(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "secrets.yml")
+	if err := writeFile(cfgPath, []byte(`
+github.com:
+  example:
+    all-repos:
+      managed:
+        vars:
+          V:
+            value: shared
+    per-repo:
+      acme:
+        managed:
+          vars:
+            V:
+              value: acme-only
+`)); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	be := &fakeBackend{}
+	if _, err := ApplyRepo(context.Background(), cfg, "example", "acme", be, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	if len(be.setVarCalls) != 1 || be.setVarCalls[0].value != "acme-only" {
+		t.Errorf("expected acme-only; got %+v", be.setVarCalls)
+	}
+}
+
+// TestApplyRepo_AllReposShieldedByPerRepoIgnored asserts that per-repo's
+// ignored list shields the repo from an all-repos.managed write.
+func TestApplyRepo_AllReposShieldedByPerRepoIgnored(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "secrets.yml")
+	if err := writeFile(cfgPath, []byte(`
+github.com:
+  example:
+    all-repos:
+      managed:
+        vars:
+          V:
+            value: shared
+    per-repo:
+      acme:
+        ignored:
+          vars:
+            - V
+`)); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	be := &fakeBackend{}
+	if _, err := ApplyRepo(context.Background(), cfg, "example", "acme", be, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	if len(be.setVarCalls) != 0 {
+		t.Errorf("per-repo.ignored must shield against all-repos.managed; got writes: %+v",
+			be.setVarCalls)
+	}
+}
+
+// TestApplyRepo_PerRepoManagedOverridesAllReposIgnored asserts that a
+// per-repo.managed entry rescues a name from all-repos.ignored.
+func TestApplyRepo_PerRepoManagedOverridesAllReposIgnored(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "secrets.yml")
+	if err := writeFile(cfgPath, []byte(`
+github.com:
+  example:
+    all-repos:
+      ignored:
+        vars:
+          - V
+    per-repo:
+      acme:
+        managed:
+          vars:
+            V:
+              value: acme-explicit
+`)); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	be := &fakeBackend{}
+	if _, err := ApplyRepo(context.Background(), cfg, "example", "acme", be, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	if len(be.setVarCalls) != 1 || be.setVarCalls[0].value != "acme-explicit" {
+		t.Errorf("per-repo.managed must override all-repos.ignored; got %+v", be.setVarCalls)
+	}
+}
+
 func TestAuditRepo_ShowIgnored(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -18,6 +18,9 @@ import (
 )
 
 type fakeBackend struct {
+	orgRepos    []string
+	orgReposErr error
+
 	vars       map[string]string
 	secrets    []string
 	dependabot []string
@@ -55,6 +58,10 @@ type setVarCall struct {
 type setSecretCall struct {
 	owner, repo, name, plaintext string
 	keyID                        string
+}
+
+func (f *fakeBackend) ListOrgRepos(_ context.Context, _ string) ([]string, error) {
+	return f.orgRepos, f.orgReposErr
 }
 
 func (f *fakeBackend) ListRepoVariables(_ context.Context, _, _ string) (map[string]string, error) {


### PR DESCRIPTION
Fixes #8

Adds the `all-repos` scope and the per-repo > all-repos cascade engine,
plus org-wide iteration when `--repo` is omitted.

## Summary

- `internal/config`: parses `all-repos.{managed,ignored}.{vars,secrets,dependabot}`
  into `Org.AllRepos`. Same managed/ignored conflict check as per-repo.
- `internal/plan`: `ForRepoCascade` produces intents using
  per-repo > all-repos precedence with `OverridesAllRepos` metadata; per-repo
  ignored shields against all-repos.managed; per-repo.managed overrides
  all-repos.ignored. `EffectiveIgnored` returns the cascaded ignored set
  for downstream diff use.
- `internal/github`: adds `ListOrgRepos` (paginated) on the Backend
  interface and `*Client`.
- `internal/runner`: per-repo functions now consume the cascade and
  tolerate repos covered only by all-repos. New `Audit`, `Apply`, `Enforce`
  iterate every org repo via `ListOrgRepos`, continue on per-repo error,
  and emit a final `summary: ok=X failed=Y` line.
- `cmd/ghsecretman`: `--repo` becomes optional on every subcommand;
  omitting it triggers the org-wide path. Enforce TTY/--yes contract is
  preserved.

## Test plan

- [x] `go test ./...` passes
- [x] `go test ./... -cover` ≥ 80% per package (lowest is 88.0%)
- [x] `golangci-lint run` clean
- [x] Plan cascade matrix covers every name-presence combination across
      all-repos.{managed,ignored} and per-repo.{managed,ignored}
- [x] Runner multi-repo iteration tests cover per-repo error continuation,
      ListOrgRepos error, repos-not-in-config skipping, and unknown org
- [x] github.ListOrgRepos tested against httptest with pagination and
      error path