### PR TITLE
runner: concurrent worker pool with atomic per-repo output

### DIFF
--- a/cmd/ghsecretman/main.go
+++ b/cmd/ghsecretman/main.go
@@ -77,6 +77,7 @@ func runEnforce(args []string, stdout, stderr io.Writer) int {
 	repo := fs.String("repo", "", "single repo to enforce; omit to iterate every repo in the org")
 	dryRun := fs.Bool("dry-run", false, "print intended writes and deletes; make no API write calls")
 	yes := fs.Bool("yes", false, "proceed without confirmation prompt")
+	concurrency := fs.Int("concurrency", runner.DefaultConcurrency, "max repos processed in parallel for org-wide runs")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
@@ -101,6 +102,7 @@ func runEnforce(args []string, stdout, stderr io.Writer) int {
 	if code != 0 {
 		return code
 	}
+	opts.Concurrency = *concurrency
 
 	if *repo != "" {
 		return runEnforceRepo(cfg, *org, *repo, backend, opts, stdout, stderr)
@@ -173,6 +175,7 @@ func runAudit(args []string, stdout, stderr io.Writer) int {
 	org := fs.String("org", "", "GitHub organization name")
 	repo := fs.String("repo", "", "single repo to audit; omit to iterate every repo in the org")
 	showIgnored := fs.Bool("show-ignored", false, "include ignored entries in output")
+	concurrency := fs.Int("concurrency", runner.DefaultConcurrency, "max repos processed in parallel for org-wide runs")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
@@ -205,7 +208,7 @@ func runAudit(args []string, stdout, stderr io.Writer) int {
 		return 0
 	}
 
-	res, err := runner.Audit(context.Background(), cfg, *org, backend, stdout, *showIgnored)
+	res, err := runner.Audit(context.Background(), cfg, *org, backend, stdout, *showIgnored, runner.OrgOptions{Concurrency: *concurrency})
 	if err != nil {
 		fmt.Fprintf(stderr, "audit: %v\n", err)
 		return 1
@@ -222,6 +225,7 @@ func runApply(args []string, stdout, stderr io.Writer) int {
 	cfgPath := fs.String("config", "", "path to YAML config file")
 	org := fs.String("org", "", "GitHub organization name")
 	repo := fs.String("repo", "", "single repo to apply; omit to iterate every repo in the org")
+	concurrency := fs.Int("concurrency", runner.DefaultConcurrency, "max repos processed in parallel for org-wide runs")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
@@ -254,7 +258,7 @@ func runApply(args []string, stdout, stderr io.Writer) int {
 		return 0
 	}
 
-	res, err := runner.Apply(context.Background(), cfg, *org, backend, stdout)
+	res, err := runner.Apply(context.Background(), cfg, *org, backend, stdout, runner.OrgOptions{Concurrency: *concurrency})
 	if err != nil {
 		fmt.Fprintf(stderr, "apply: %v\n", err)
 		return 1

--- a/cmd/ghsecretman/main_test.go
+++ b/cmd/ghsecretman/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	gh "github.com/schmidtw/ghsecretman/internal/github"
@@ -77,6 +78,7 @@ type fakeBackend struct {
 	secrets    []string
 	dependabot []string
 
+	mu            sync.Mutex
 	setVars       []string
 	setSecrets    []string
 	setDependabot []string
@@ -109,31 +111,43 @@ func (f *fakeBackend) GetRepoDependabotPublicKey(_ context.Context, _, _ string)
 }
 
 func (f *fakeBackend) SetRepoVariable(_ context.Context, _, _, name, _ string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.setVars = append(f.setVars, name)
 	return nil
 }
 
 func (f *fakeBackend) SetRepoSecret(_ context.Context, _, _, name string, _ *gh.PublicKey, _ string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.setSecrets = append(f.setSecrets, name)
 	return nil
 }
 
 func (f *fakeBackend) SetRepoDependabotSecret(_ context.Context, _, _, name string, _ *gh.PublicKey, _ string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.setDependabot = append(f.setDependabot, name)
 	return nil
 }
 
 func (f *fakeBackend) DeleteRepoVariable(_ context.Context, _, _, name string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.delVars = append(f.delVars, name)
 	return nil
 }
 
 func (f *fakeBackend) DeleteRepoSecret(_ context.Context, _, _, name string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.delSecrets = append(f.delSecrets, name)
 	return nil
 }
 
 func (f *fakeBackend) DeleteRepoDependabotSecret(_ context.Context, _, _, name string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.delDependabot = append(f.delDependabot, name)
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.0
 require (
 	github.com/google/go-github/v85 v85.0.0
 	golang.org/x/crypto v0.50.0
+	golang.org/x/sync v0.20.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfh
 github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJZD5A0egEOmkqU=
 golang.org/x/crypto v0.50.0 h1:zO47/JPrL6vsNkINmLoo/PH1gcxpls50DNogFvB5ZGI=
 golang.org/x/crypto v0.50.0/go.mod h1:3muZ7vA7PBCE6xgPX7nkzzjiUq87kRItoJQM1Yo8S+Q=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
 golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -7,10 +7,14 @@
 package runner
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"os"
+	"sync"
+
+	"golang.org/x/sync/errgroup"
 
 	"github.com/schmidtw/ghsecretman/internal/config"
 	"github.com/schmidtw/ghsecretman/internal/diff"
@@ -18,6 +22,24 @@ import (
 	"github.com/schmidtw/ghsecretman/internal/plan"
 	"github.com/schmidtw/ghsecretman/internal/resolve"
 )
+
+// DefaultConcurrency is the worker-pool size when OrgOptions.Concurrency is
+// zero or negative.
+const DefaultConcurrency = 8
+
+// OrgOptions configures org-wide iteration shared by Audit and Apply.
+type OrgOptions struct {
+	// Concurrency bounds the number of repos processed in parallel. Zero
+	// or negative selects DefaultConcurrency.
+	Concurrency int
+}
+
+func resolveConcurrency(n int) int {
+	if n <= 0 {
+		return DefaultConcurrency
+	}
+	return n
+}
 
 // Result reports the outcome of a single-repo run.
 //
@@ -225,6 +247,10 @@ type EnforceOptions struct {
 	// since neither is needed without a real write.
 	DryRun bool
 
+	// Concurrency bounds org-wide enforce iteration the same way
+	// OrgOptions.Concurrency does for Audit/Apply.
+	Concurrency int
+
 	// Confirm, if non-nil and DryRun is false, is invoked after the live
 	// state has been fetched and the extras list computed. The argument
 	// is a list of "kind/name" strings, one per planned deletion. If
@@ -373,108 +399,154 @@ type OrgResult struct {
 	FailedEntries int
 	// OkRepos is the count of repos that completed without a per-repo error.
 	OkRepos int
+	// SkippedRepos is the count of repos returned by ListOrgRepos that
+	// the config does not address (no per-repo entry and no all-repos).
+	SkippedRepos int
 	// FailedRepos is the count of repos whose top-level call returned an error.
 	FailedRepos int
 }
 
-// targetRepos returns the org repos that will be processed: every name from
-// ListOrgRepos for which either all-repos applies or a per-repo entry exists.
+// targetRepos returns the org repos this run will process and the count of
+// repos returned by ListOrgRepos that the config does not address.
 //
-// Repos not addressed by config are skipped silently — there is nothing to
-// audit, apply, or enforce on them.
-func targetRepos(ctx context.Context, backend gh.Backend, o *config.Org, org string) ([]string, error) {
+// A repo is addressed when either an all-repos block exists or the org has
+// a per-repo entry for it. Unaddressed repos are skipped silently — there
+// is nothing to audit, apply, or enforce on them — but they are counted so
+// the summary line can report them.
+func targetRepos(ctx context.Context, backend gh.Backend, o *config.Org, org string) ([]string, int, error) {
 	all, err := backend.ListOrgRepos(ctx, org)
 	if err != nil {
-		return nil, fmt.Errorf("list org repos: %w", err)
+		return nil, 0, fmt.Errorf("list org repos: %w", err)
 	}
 	out := make([]string, 0, len(all))
+	skipped := 0
 	for _, r := range all {
 		if o.AllRepos != nil || o.PerRepo[r] != nil {
 			out = append(out, r)
+			continue
 		}
+		skipped++
 	}
-	return out, nil
+	return out, skipped, nil
 }
 
-// Audit runs an audit across every repo in the org. Per-repo errors are
-// reported and the run continues. The final summary line counts ok and
-// failed repos.
-func Audit(ctx context.Context, cfg *config.Config, org string, backend gh.Backend, out io.Writer, showIgnored bool) (OrgResult, error) {
+// repoWork is the per-repo unit of work passed to the worker pool. It
+// renders into a local buffer; the caller flushes the buffer to the shared
+// writer atomically.
+type repoWork func(ctx context.Context, buf *bytes.Buffer) (Result, error)
+
+// runOrg runs work for each repo concurrently, bounding parallelism by
+// concurrency. Per-repo output is accumulated in a local buffer and then
+// flushed atomically to out (so two repos' lines never interleave).
+//
+// On per-repo error, an "ERROR:" stanza is written and the run continues.
+// The caller supplies a function that builds the work closure for each
+// repo name; this lets Audit/Apply/Enforce share the iteration scaffolding
+// without forcing them through a single signature.
+func runOrg(ctx context.Context, repos []string, concurrency int, out io.Writer, build func(repo string) repoWork) OrgResult {
+	concurrency = resolveConcurrency(concurrency)
+	var (
+		mu  sync.Mutex
+		res OrgResult
+	)
+	flush := func(buf *bytes.Buffer) {
+		mu.Lock()
+		defer mu.Unlock()
+		_, _ = out.Write(buf.Bytes())
+	}
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(concurrency)
+	for _, repo := range repos {
+		work := build(repo)
+		g.Go(func() error {
+			var buf bytes.Buffer
+			r, err := work(gctx, &buf)
+			if err != nil {
+				fmt.Fprintf(&buf, "repo: %s\n  ERROR: %v\n", repo, err)
+				flush(&buf)
+				mu.Lock()
+				res.FailedRepos++
+				mu.Unlock()
+				return nil
+			}
+			flush(&buf)
+			mu.Lock()
+			res.OkRepos++
+			res.FailedEntries += r.Failed
+			if r.Drift {
+				res.Drift = true
+			}
+			mu.Unlock()
+			return nil
+		})
+	}
+	_ = g.Wait()
+	return res
+}
+
+// Audit runs an audit across every repo in the org concurrently. Per-repo
+// errors are reported and the run continues. The final summary line counts
+// ok, skipped, and failed repos.
+func Audit(ctx context.Context, cfg *config.Config, org string, backend gh.Backend, out io.Writer, showIgnored bool, opts OrgOptions) (OrgResult, error) {
 	o, ok := cfg.Org(org)
 	if !ok {
 		return OrgResult{}, fmt.Errorf("org %q not found in config", org)
 	}
-	repos, err := targetRepos(ctx, backend, o, org)
+	repos, skipped, err := targetRepos(ctx, backend, o, org)
 	if err != nil {
 		return OrgResult{}, err
 	}
-	var res OrgResult
-	for _, repo := range repos {
-		r, err := AuditRepo(ctx, cfg, org, repo, backend, out, showIgnored)
-		if err != nil {
-			fmt.Fprintf(out, "repo: %s\n  ERROR: %v\n", repo, err)
-			res.FailedRepos++
-			continue
+	res := runOrg(ctx, repos, opts.Concurrency, out, func(repo string) repoWork {
+		return func(ctx context.Context, buf *bytes.Buffer) (Result, error) {
+			return AuditRepo(ctx, cfg, org, repo, backend, buf, showIgnored)
 		}
-		if r.Drift {
-			res.Drift = true
-		}
-		res.OkRepos++
-	}
-	fmt.Fprintf(out, "summary: ok=%d failed=%d\n", res.OkRepos, res.FailedRepos)
+	})
+	res.SkippedRepos = skipped
+	fmt.Fprintf(out, "summary: ok=%d skipped=%d failed=%d\n", res.OkRepos, res.SkippedRepos, res.FailedRepos)
 	return res, nil
 }
 
-// Apply runs apply across every repo in the org. Per-repo errors are
-// reported and the run continues; per-entry write failures are summed
-// into FailedEntries.
-func Apply(ctx context.Context, cfg *config.Config, org string, backend gh.Backend, out io.Writer) (OrgResult, error) {
+// Apply runs apply across every repo in the org concurrently. Per-repo
+// errors are reported and the run continues; per-entry write failures are
+// summed into FailedEntries.
+func Apply(ctx context.Context, cfg *config.Config, org string, backend gh.Backend, out io.Writer, opts OrgOptions) (OrgResult, error) {
 	o, ok := cfg.Org(org)
 	if !ok {
 		return OrgResult{}, fmt.Errorf("org %q not found in config", org)
 	}
-	repos, err := targetRepos(ctx, backend, o, org)
+	repos, skipped, err := targetRepos(ctx, backend, o, org)
 	if err != nil {
 		return OrgResult{}, err
 	}
-	var res OrgResult
-	for _, repo := range repos {
-		r, err := ApplyRepo(ctx, cfg, org, repo, backend, out)
-		if err != nil {
-			fmt.Fprintf(out, "repo: %s\n  ERROR: %v\n", repo, err)
-			res.FailedRepos++
-			continue
+	res := runOrg(ctx, repos, opts.Concurrency, out, func(repo string) repoWork {
+		return func(ctx context.Context, buf *bytes.Buffer) (Result, error) {
+			return ApplyRepo(ctx, cfg, org, repo, backend, buf)
 		}
-		res.FailedEntries += r.Failed
-		res.OkRepos++
-	}
-	fmt.Fprintf(out, "summary: ok=%d failed=%d\n", res.OkRepos, res.FailedRepos)
+	})
+	res.SkippedRepos = skipped
+	fmt.Fprintf(out, "summary: ok=%d skipped=%d failed=%d\n", res.OkRepos, res.SkippedRepos, res.FailedRepos)
 	return res, nil
 }
 
-// Enforce runs enforce across every repo in the org. The provided opts
-// are forwarded to each EnforceRepo call.
+// Enforce runs enforce across every repo in the org concurrently. The
+// provided opts are forwarded to each EnforceRepo call.
 func Enforce(ctx context.Context, cfg *config.Config, org string, backend gh.Backend, out io.Writer, opts EnforceOptions) (OrgResult, error) {
 	o, ok := cfg.Org(org)
 	if !ok {
 		return OrgResult{}, fmt.Errorf("org %q not found in config", org)
 	}
-	repos, err := targetRepos(ctx, backend, o, org)
+	repos, skipped, err := targetRepos(ctx, backend, o, org)
 	if err != nil {
 		return OrgResult{}, err
 	}
-	var res OrgResult
-	for _, repo := range repos {
-		r, err := EnforceRepo(ctx, cfg, org, repo, backend, out, opts)
-		if err != nil {
-			fmt.Fprintf(out, "repo: %s\n  ERROR: %v\n", repo, err)
-			res.FailedRepos++
-			continue
+	res := runOrg(ctx, repos, opts.Concurrency, out, func(repo string) repoWork {
+		return func(ctx context.Context, buf *bytes.Buffer) (Result, error) {
+			return EnforceRepo(ctx, cfg, org, repo, backend, buf, opts)
 		}
-		res.FailedEntries += r.Failed
-		res.OkRepos++
-	}
-	fmt.Fprintf(out, "summary: ok=%d failed=%d\n", res.OkRepos, res.FailedRepos)
+	})
+	res.SkippedRepos = skipped
+	fmt.Fprintf(out, "summary: ok=%d skipped=%d failed=%d\n", res.OkRepos, res.SkippedRepos, res.FailedRepos)
 	return res, nil
 }
 

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -4,6 +4,7 @@
 package runner
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"errors"
@@ -11,6 +12,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/schmidtw/ghsecretman/internal/config"
@@ -1298,7 +1300,7 @@ github.com:
 		vars:     map[string]string{"ALL_VAR": "ok"},
 	}
 	var out bytes.Buffer
-	res, err := Audit(context.Background(), cfg, "example", be, &out, false)
+	res, err := Audit(context.Background(), cfg, "example", be, &out, false, OrgOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1310,7 +1312,7 @@ github.com:
 			res.OkRepos, res.FailedRepos)
 	}
 	s := out.String()
-	for _, want := range []string{"repo: acme", "repo: beta", "summary: ok=2 failed=0"} {
+	for _, want := range []string{"repo: acme", "repo: beta", "summary: ok=2 skipped=0 failed=0"} {
 		if !strings.Contains(s, want) {
 			t.Errorf("output missing %q\n--\n%s", want, s)
 		}
@@ -1342,7 +1344,7 @@ github.com:
 		vars:     map[string]string{"V": "ok"},
 	}
 	var out bytes.Buffer
-	res, err := Audit(context.Background(), cfg, "example", be, &out, false)
+	res, err := Audit(context.Background(), cfg, "example", be, &out, false, OrgOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1379,7 +1381,7 @@ github.com:
 		err:      errors.New("boom"),
 	}
 	var out bytes.Buffer
-	res, err := Audit(context.Background(), cfg, "example", be, &out, false)
+	res, err := Audit(context.Background(), cfg, "example", be, &out, false, OrgOptions{})
 	if err != nil {
 		t.Fatalf("Audit should continue on per-repo error, not return one: %v", err)
 	}
@@ -1390,7 +1392,7 @@ github.com:
 	if !strings.Contains(s, "ERROR: ") {
 		t.Errorf("expected ERROR line in output:\n%s", s)
 	}
-	if !strings.Contains(s, "summary: ok=0 failed=2") {
+	if !strings.Contains(s, "summary: ok=0 skipped=0 failed=2") {
 		t.Errorf("expected summary line: %q", s)
 	}
 }
@@ -1412,7 +1414,7 @@ github.com:
 		t.Fatal(err)
 	}
 	be := &fakeBackend{orgReposErr: errors.New("forbidden")}
-	if _, err := Audit(context.Background(), cfg, "example", be, &bytes.Buffer{}, false); err == nil {
+	if _, err := Audit(context.Background(), cfg, "example", be, &bytes.Buffer{}, false, OrgOptions{}); err == nil {
 		t.Fatal("expected error when ListOrgRepos fails")
 	}
 }
@@ -1420,7 +1422,7 @@ github.com:
 func TestAudit_UnknownOrg(t *testing.T) {
 	t.Parallel()
 	cfg := &config.Config{Orgs: map[string]*config.Org{}}
-	if _, err := Audit(context.Background(), cfg, "missing", &fakeBackend{}, &bytes.Buffer{}, false); err == nil {
+	if _, err := Audit(context.Background(), cfg, "missing", &fakeBackend{}, &bytes.Buffer{}, false, OrgOptions{}); err == nil {
 		t.Fatal("expected error for unknown org")
 	}
 }
@@ -1452,7 +1454,7 @@ github.com:
 	}
 	be := &fakeBackend{orgRepos: []string{"acme", "beta"}}
 	var out bytes.Buffer
-	res, err := Apply(context.Background(), cfg, "example", be, &out)
+	res, err := Apply(context.Background(), cfg, "example", be, &out, OrgOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1477,7 +1479,7 @@ github.com:
 func TestApply_UnknownOrg(t *testing.T) {
 	t.Parallel()
 	cfg := &config.Config{Orgs: map[string]*config.Org{}}
-	if _, err := Apply(context.Background(), cfg, "missing", &fakeBackend{}, &bytes.Buffer{}); err == nil {
+	if _, err := Apply(context.Background(), cfg, "missing", &fakeBackend{}, &bytes.Buffer{}, OrgOptions{}); err == nil {
 		t.Fatal("expected error")
 	}
 }
@@ -1488,7 +1490,7 @@ func TestApply_ListOrgReposError(t *testing.T) {
 		"example": {AllRepos: &config.Repo{}},
 	}}
 	be := &fakeBackend{orgReposErr: errors.New("boom")}
-	if _, err := Apply(context.Background(), cfg, "example", be, &bytes.Buffer{}); err == nil {
+	if _, err := Apply(context.Background(), cfg, "example", be, &bytes.Buffer{}, OrgOptions{}); err == nil {
 		t.Fatal("expected error")
 	}
 }
@@ -1719,5 +1721,373 @@ github.com:
 	}
 	if !strings.Contains(out.String(), "IG_VAR") {
 		t.Errorf("expected IG_VAR in output with showIgnored=true; got:\n%s", out.String())
+	}
+}
+
+// gatedBackend extends fakeBackend with a per-call gate. Every call to
+// ListRepoVariables increments inFlight (then decrements on return) and
+// observes maxInFlight, letting tests assert that no more than the
+// configured concurrency runs at once.
+type gatedBackend struct {
+	fakeBackend
+	inFlight    atomic.Int32
+	maxInFlight atomic.Int32
+	release     chan struct{}
+}
+
+func (g *gatedBackend) ListRepoVariables(_ context.Context, _, _ string) (map[string]string, error) {
+	cur := g.inFlight.Add(1)
+	for {
+		hi := g.maxInFlight.Load()
+		if cur <= hi || g.maxInFlight.CompareAndSwap(hi, cur) {
+			break
+		}
+	}
+	if g.release != nil {
+		<-g.release
+	}
+	g.inFlight.Add(-1)
+	return g.vars, g.err
+}
+
+func TestAudit_RespectsConcurrencyLimit(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "secrets.yml")
+	if err := writeFile(cfgPath, []byte(`
+github.com:
+  example:
+    all-repos:
+      managed:
+        vars:
+          V:
+            value: ok
+`)); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repoNames := make([]string, 0, 32)
+	for i := range 32 {
+		repoNames = append(repoNames, "r-"+string(rune('a'+i%26))+string(rune('a'+i/26)))
+	}
+	be := &gatedBackend{
+		fakeBackend: fakeBackend{
+			orgRepos: repoNames,
+			vars:     map[string]string{"V": "ok"},
+		},
+		release: make(chan struct{}, len(repoNames)),
+	}
+	for range repoNames {
+		be.release <- struct{}{}
+	}
+
+	var out bytes.Buffer
+	limit := 4
+	if _, err := Audit(context.Background(), cfg, "example", be, &out, false, OrgOptions{Concurrency: limit}); err != nil {
+		t.Fatal(err)
+	}
+	if got := int(be.maxInFlight.Load()); got > limit {
+		t.Errorf("max concurrent ListRepoVariables=%d exceeds limit=%d", got, limit)
+	}
+}
+
+// TestAudit_AtomicPerRepoOutput asserts that per-repo stanzas never
+// interleave even when many repos run in parallel. Each stanza begins with
+// "repo: <name>"; once a stanza begins, all subsequent indented lines must
+// belong to that same repo until the next "repo:" header.
+func TestAudit_AtomicPerRepoOutput(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "secrets.yml")
+	if err := writeFile(cfgPath, []byte(`
+github.com:
+  example:
+    all-repos:
+      managed:
+        vars:
+          A:
+            value: ok
+          B:
+            value: ok
+          C:
+            value: ok
+`)); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const n = 16
+	repoNames := make([]string, 0, n)
+	for i := range n {
+		repoNames = append(repoNames, "r"+string(rune('a'+i%26))+string(rune('A'+i/26)))
+	}
+	be := &fakeBackend{
+		orgRepos: repoNames,
+		vars:     map[string]string{"A": "ok", "B": "ok", "C": "ok"},
+	}
+
+	var out bytes.Buffer
+	if _, err := Audit(context.Background(), cfg, "example", be, &out, false, OrgOptions{Concurrency: 8}); err != nil {
+		t.Fatal(err)
+	}
+
+	scan := bufio.NewScanner(strings.NewReader(out.String()))
+	currentRepo := ""
+	seenRepos := map[string]bool{}
+	for scan.Scan() {
+		line := scan.Text()
+		switch {
+		case strings.HasPrefix(line, "repo: "):
+			currentRepo = strings.TrimPrefix(line, "repo: ")
+			if seenRepos[currentRepo] {
+				t.Fatalf("repo %q stanza appears more than once (interleaved):\n%s",
+					currentRepo, out.String())
+			}
+			seenRepos[currentRepo] = true
+		case strings.HasPrefix(line, "  "):
+			if currentRepo == "" {
+				t.Fatalf("indented line before any repo header:\n%q\nfull output:\n%s", line, out.String())
+			}
+		default:
+			currentRepo = ""
+		}
+	}
+	if len(seenRepos) != n {
+		t.Errorf("expected %d distinct repo stanzas, got %d", n, len(seenRepos))
+	}
+}
+
+func TestAudit_DefaultConcurrencyWhenZero(t *testing.T) {
+	t.Parallel()
+	if got := resolveConcurrency(0); got != DefaultConcurrency {
+		t.Errorf("resolveConcurrency(0)=%d; want %d", got, DefaultConcurrency)
+	}
+	if got := resolveConcurrency(-3); got != DefaultConcurrency {
+		t.Errorf("resolveConcurrency(-3)=%d; want %d", got, DefaultConcurrency)
+	}
+	if got := resolveConcurrency(2); got != 2 {
+		t.Errorf("resolveConcurrency(2)=%d; want 2", got)
+	}
+}
+
+func TestAudit_SkippedCount(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "secrets.yml")
+	if err := writeFile(cfgPath, []byte(`
+github.com:
+  example:
+    per-repo:
+      acme:
+        managed:
+          vars:
+            V:
+              value: ok
+`)); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	be := &fakeBackend{
+		orgRepos: []string{"acme", "unrelated", "also-unrelated"},
+		vars:     map[string]string{"V": "ok"},
+	}
+	var out bytes.Buffer
+	res, err := Audit(context.Background(), cfg, "example", be, &out, false, OrgOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.OkRepos != 1 {
+		t.Errorf("ok=%d want 1", res.OkRepos)
+	}
+	if res.SkippedRepos != 2 {
+		t.Errorf("skipped=%d want 2", res.SkippedRepos)
+	}
+	if !strings.Contains(out.String(), "summary: ok=1 skipped=2 failed=0") {
+		t.Errorf("summary line missing; got:\n%s", out.String())
+	}
+}
+
+// TestAudit_ExitCodeMatrix exercises the four cases the issue calls out:
+// {clean, drift-only, failure-only, both}. Exit codes are derived in the
+// CLI from (Drift, FailedRepos) — here we assert the OrgResult fields the
+// CLI inspects.
+func TestAudit_ExitCodeMatrix(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "secrets.yml")
+	if err := writeFile(cfgPath, []byte(`
+github.com:
+  example:
+    all-repos:
+      managed:
+        vars:
+          V:
+            value: ok
+`)); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name        string
+		live        map[string]string
+		listErr     error
+		wantDrift   bool
+		wantFailed  int
+		wantOk      int
+		wantNonzero bool
+	}{
+		{
+			name:        "clean",
+			live:        map[string]string{"V": "ok"},
+			wantOk:      2,
+			wantNonzero: false,
+		},
+		{
+			name:        "drift-only",
+			live:        map[string]string{"V": "different"},
+			wantDrift:   true,
+			wantOk:      2,
+			wantNonzero: true,
+		},
+		{
+			name:        "failure-only",
+			listErr:     errors.New("boom"),
+			wantFailed:  2,
+			wantNonzero: true,
+		},
+		{
+			name:        "both-drift-and-failure",
+			live:        map[string]string{"V": "different"},
+			listErr:     errors.New("boom"), // err short-circuits before drift, so failure dominates
+			wantFailed:  2,
+			wantNonzero: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			be := &fakeBackend{
+				orgRepos: []string{"a", "b"},
+				vars:     tc.live,
+				err:      tc.listErr,
+			}
+			res, err := Audit(context.Background(), cfg, "example", be, &bytes.Buffer{}, false, OrgOptions{})
+			if err != nil {
+				t.Fatalf("Audit returned err: %v", err)
+			}
+			if res.Drift != tc.wantDrift {
+				t.Errorf("Drift=%v want %v", res.Drift, tc.wantDrift)
+			}
+			if res.FailedRepos != tc.wantFailed {
+				t.Errorf("FailedRepos=%d want %d", res.FailedRepos, tc.wantFailed)
+			}
+			if res.OkRepos != tc.wantOk {
+				t.Errorf("OkRepos=%d want %d", res.OkRepos, tc.wantOk)
+			}
+			nonzero := res.Drift || res.FailedRepos > 0
+			if nonzero != tc.wantNonzero {
+				t.Errorf("derived nonzero exit=%v want %v", nonzero, tc.wantNonzero)
+			}
+		})
+	}
+}
+
+func TestApply_PartialFailureContinues(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "secrets.yml")
+	if err := writeFile(cfgPath, []byte(`
+github.com:
+  example:
+    all-repos:
+      managed:
+        vars:
+          V:
+            value: ok
+`)); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	be := &fakeBackend{
+		orgRepos: []string{"a", "b", "c"},
+		setErr:   map[string]error{"vars/V": errors.New("rate limit")},
+	}
+	var out bytes.Buffer
+	res, err := Apply(context.Background(), cfg, "example", be, &out, OrgOptions{Concurrency: 3})
+	if err != nil {
+		t.Fatalf("apply should not return an error on per-entry failures: %v", err)
+	}
+	if res.OkRepos != 3 {
+		t.Errorf("OkRepos=%d want 3 (per-repo wrapper succeeds; failure is per-entry)", res.OkRepos)
+	}
+	if res.FailedEntries != 3 {
+		t.Errorf("FailedEntries=%d want 3 (one per repo)", res.FailedEntries)
+	}
+	if !strings.Contains(out.String(), "summary: ok=3 skipped=0 failed=0") {
+		t.Errorf("summary line missing or wrong; got:\n%s", out.String())
+	}
+}
+
+func TestEnforce_AtomicOutputDryRun(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "secrets.yml")
+	if err := writeFile(cfgPath, []byte(`
+github.com:
+  example:
+    all-repos:
+      managed:
+        vars:
+          V:
+            value: ok
+`)); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	be := &fakeBackend{
+		orgRepos: []string{"a", "b", "c", "d"},
+		vars:     map[string]string{"EXTRA": "x"},
+	}
+	var out bytes.Buffer
+	res, err := Enforce(context.Background(), cfg, "example", be, &out, EnforceOptions{DryRun: true, Concurrency: 4})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.OkRepos != 4 {
+		t.Errorf("OkRepos=%d want 4", res.OkRepos)
+	}
+	if !strings.Contains(out.String(), "summary: ok=4 skipped=0 failed=0") {
+		t.Errorf("summary missing; got:\n%s", out.String())
+	}
+	scan := bufio.NewScanner(strings.NewReader(out.String()))
+	seen := map[string]bool{}
+	for scan.Scan() {
+		line := scan.Text()
+		name, ok := strings.CutPrefix(line, "repo: ")
+		if !ok {
+			continue
+		}
+		if seen[name] {
+			t.Fatalf("repo %q stanza split (interleaved):\n%s", name, out.String())
+		}
+		seen[name] = true
 	}
 }


### PR DESCRIPTION
Fixes #9

Replaces serial repo iteration in `internal/runner` with a bounded
worker pool (errgroup + `SetLimit`). Per-repo output renders into a
local buffer and is flushed under a mutex, so concurrent stanzas never
interleave.

## Summary

- `OrgOptions{Concurrency}` (and `EnforceOptions.Concurrency`) bound the
  pool; default 8 via `runner.DefaultConcurrency`.
- CLI gains `--concurrency <n>` on `audit`, `apply`, and `enforce`.
- Per-repo failures are recorded and the run continues.
- Summary line is now `summary: ok=<n> skipped=<n> failed=<n>`. Skipped
  counts repos returned by `ListOrgRepos` that the config does not
  address.
- Exit-code policy unchanged: nonzero when any per-repo failure or (for
  audit) any drift.

## Test plan

- [x] `go test ./...` (with and without `-race`)
- [x] `go test ./... -cover` — every package ≥ 80%
- [x] `golangci-lint run` clean
- [x] New runner tests cover: concurrency limit honored, atomic stanza
      ordering at concurrency=8, skipped count, exit-code matrix
      (clean / drift-only / failure-only / both), partial-failure
      summary