### PR TITLE
Slice 9: org scope (org-level secrets/vars/dependabot with visibility)

### DIFF
--- a/cmd/ghsecretman/main_test.go
+++ b/cmd/ghsecretman/main_test.go
@@ -800,3 +800,78 @@ github.com:
 		t.Errorf("stdout missing FAILED line: %q", stdout.String())
 	}
 }
+
+func TestRun_AuditOrgWide_IncludesOrgScope(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeCfg(t, dir, `
+github.com:
+  example:
+    org:
+      managed:
+        vars:
+          ORG_VAR:
+            value: x
+    per-repo:
+      acme:
+        managed:
+          vars:
+            REPO_VAR:
+              value: y
+`)
+	be := &fakeBackend{
+		orgRepos: []string{"acme"},
+		vars:     map[string]string{"REPO_VAR": "y"},
+		orgVars:  map[string]string{"ORG_VAR": "x"},
+	}
+	swapBackend(t, be, nil)
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"ghsecretman", "audit", "--config", cfgPath, "--org", "example"}, "dev", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit: got %d want 0; stderr=%q\nstdout=%q", code, stderr.String(), stdout.String())
+	}
+	for _, want := range []string{"scope: org", "repo: acme", "summary: ok=1"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Errorf("stdout missing %q\n--\n%s", want, stdout.String())
+		}
+	}
+}
+
+func TestRun_ApplyOrgWide_WritesOrgScope_Selected(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeCfg(t, dir, `
+github.com:
+  example:
+    org:
+      managed:
+        vars:
+          ORG_VAR:
+            value: x
+            scope: selected
+            repos:
+              - acme
+    per-repo:
+      acme:
+        managed:
+          vars:
+            REPO_VAR:
+              value: y
+`)
+	be := &fakeBackend{
+		orgRepos: []string{"acme"},
+		repoIDs:  map[string]int64{"acme": 42},
+	}
+	swapBackend(t, be, nil)
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"ghsecretman", "apply", "--config", cfgPath, "--org", "example"}, "dev", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit: got %d want 0; stderr=%q\nstdout=%q", code, stderr.String(), stdout.String())
+	}
+	if len(be.setOrgVars) != 1 || be.setOrgVars[0] != "ORG_VAR" {
+		t.Errorf("expected one ORG_VAR set; got %v", be.setOrgVars)
+	}
+	if len(be.setVars) != 1 {
+		t.Errorf("expected one repo var set; got %v", be.setVars)
+	}
+}

--- a/cmd/ghsecretman/main_test.go
+++ b/cmd/ghsecretman/main_test.go
@@ -86,6 +86,20 @@ type fakeBackend struct {
 	delVars       []string
 	delSecrets    []string
 	delDependabot []string
+
+	orgVars       map[string]string
+	orgSecrets    []string
+	orgDependabot []string
+
+	setOrgVars       []string
+	setOrgSecrets    []string
+	setOrgDependabot []string
+
+	delOrgVars       []string
+	delOrgSecrets    []string
+	delOrgDependabot []string
+
+	repoIDs map[string]int64
 }
 
 func (f *fakeBackend) ListOrgRepos(_ context.Context, _ string) ([]string, error) {
@@ -150,6 +164,64 @@ func (f *fakeBackend) DeleteRepoDependabotSecret(_ context.Context, _, _, name s
 	defer f.mu.Unlock()
 	f.delDependabot = append(f.delDependabot, name)
 	return nil
+}
+
+func (f *fakeBackend) ListOrgVariables(_ context.Context, _ string) (map[string]string, error) {
+	return f.orgVars, nil
+}
+func (f *fakeBackend) ListOrgSecrets(_ context.Context, _ string) ([]string, error) {
+	return f.orgSecrets, nil
+}
+func (f *fakeBackend) ListOrgDependabotSecrets(_ context.Context, _ string) ([]string, error) {
+	return f.orgDependabot, nil
+}
+func (f *fakeBackend) GetOrgPublicKey(_ context.Context, _ string) (*gh.PublicKey, error) {
+	return &gh.PublicKey{KeyID: "org-actions-kid", Key: "AAAA"}, nil
+}
+func (f *fakeBackend) GetOrgDependabotPublicKey(_ context.Context, _ string) (*gh.PublicKey, error) {
+	return &gh.PublicKey{KeyID: "org-dep-kid", Key: "BBBB"}, nil
+}
+func (f *fakeBackend) SetOrgVariable(_ context.Context, _, name, _, _ string, _ []int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.setOrgVars = append(f.setOrgVars, name)
+	return nil
+}
+func (f *fakeBackend) SetOrgSecret(_ context.Context, _, name string, _ *gh.PublicKey, _, _ string, _ []int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.setOrgSecrets = append(f.setOrgSecrets, name)
+	return nil
+}
+func (f *fakeBackend) SetOrgDependabotSecret(_ context.Context, _, name string, _ *gh.PublicKey, _, _ string, _ []int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.setOrgDependabot = append(f.setOrgDependabot, name)
+	return nil
+}
+func (f *fakeBackend) DeleteOrgVariable(_ context.Context, _, name string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.delOrgVars = append(f.delOrgVars, name)
+	return nil
+}
+func (f *fakeBackend) DeleteOrgSecret(_ context.Context, _, name string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.delOrgSecrets = append(f.delOrgSecrets, name)
+	return nil
+}
+func (f *fakeBackend) DeleteOrgDependabotSecret(_ context.Context, _, name string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.delOrgDependabot = append(f.delOrgDependabot, name)
+	return nil
+}
+func (f *fakeBackend) GetRepoID(_ context.Context, _, repo string) (int64, error) {
+	if id, ok := f.repoIDs[repo]; ok {
+		return id, nil
+	}
+	return 0, nil
 }
 
 func writeCfg(t *testing.T, dir, body string) string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -235,6 +235,10 @@ func checkOrgManagedIgnoredConflict(orgName string, s *OrgScope) error {
 	return nil
 }
 
+// decodeOrgManaged parses the org-level managed block.
+//
+//nolint:dupl // structurally similar to decodeManaged but produces OrgManaged
+// (whose entries carry visibility/repos) rather than Managed.
 func decodeOrgManaged(baseDir, orgName string, n *yaml.Node) (OrgManaged, error) {
 	var m OrgManaged
 	if n.Kind != yaml.MappingNode {
@@ -407,6 +411,11 @@ func checkManagedIgnoredConflict(repoName string, r *Repo) error {
 	return nil
 }
 
+// decodeManaged parses the repo-level managed block.
+//
+//nolint:dupl // structurally similar to decodeOrgManaged but produces a
+// different type (Managed vs OrgManaged). Refactoring across types adds more
+// indirection than it removes; the two are short and easy to read in place.
 func decodeManaged(baseDir, repoName string, n *yaml.Node) (Managed, error) {
 	var m Managed
 	if n.Kind != yaml.MappingNode {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,10 +25,36 @@ func (c *Config) Org(name string) (*Org, bool) {
 
 // Org holds per-organization configuration.
 type Org struct {
+	// OrgScope, when set, holds values written at the GitHub organization
+	// level (separate object class from repo-level secrets/variables).
+	OrgScope *OrgScope
 	// AllRepos, when set, holds values to fan out to every repo in the org.
 	// Per-repo entries override or shield individual repos.
 	AllRepos *Repo
 	PerRepo  map[string]*Repo
+}
+
+// OrgScope holds the org-level managed/ignored blocks.
+type OrgScope struct {
+	Managed OrgManaged
+	Ignored Ignored
+}
+
+// OrgManaged lists org-level values the tool owns and may write.
+type OrgManaged struct {
+	Vars       map[string]*OrgEntry
+	Secrets    map[string]*OrgEntry
+	Dependabot map[string]*OrgEntry
+}
+
+// OrgEntry describes one org-managed value with its visibility envelope.
+type OrgEntry struct {
+	Entry *Entry
+	// Visibility is one of "all", "private", "selected". Default: "all".
+	Visibility string
+	// Repos is the static list of repo names that may access the entry when
+	// Visibility == "selected". Required iff Visibility == "selected".
+	Repos []string
 }
 
 // Repo holds per-repo configuration.
@@ -145,13 +171,188 @@ func decodeOrg(baseDir, orgName string, n *yaml.Node) (*Org, error) {
 			}
 			org.AllRepos = repo
 		case "org":
-			// Out of scope for this slice; reserved for future slices.
-			return nil, fmt.Errorf("org %q: scope %q not yet supported", orgName, key)
+			s, err := decodeOrgScope(baseDir, orgName, val)
+			if err != nil {
+				return nil, err
+			}
+			org.OrgScope = s
 		default:
 			return nil, fmt.Errorf("org %q: unknown key %q", orgName, key)
 		}
 	}
 	return org, nil
+}
+
+func decodeOrgScope(baseDir, orgName string, n *yaml.Node) (*OrgScope, error) {
+	if n.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("org %q: org must be a mapping", orgName)
+	}
+	s := &OrgScope{}
+	for i := 0; i < len(n.Content); i += 2 {
+		key := n.Content[i].Value
+		val := n.Content[i+1]
+		switch key {
+		case "managed":
+			m, err := decodeOrgManaged(baseDir, orgName, val)
+			if err != nil {
+				return nil, err
+			}
+			s.Managed = m
+		case "ignored":
+			ig, err := decodeIgnored(fmt.Sprintf("org %q", orgName), val)
+			if err != nil {
+				return nil, err
+			}
+			s.Ignored = ig
+		default:
+			return nil, fmt.Errorf("org %q: org: unknown key %q", orgName, key)
+		}
+	}
+	if err := checkOrgManagedIgnoredConflict(orgName, s); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func checkOrgManagedIgnoredConflict(orgName string, s *OrgScope) error {
+	conflicts := []struct {
+		section string
+		managed map[string]*OrgEntry
+		ignored []string
+	}{
+		{"vars", s.Managed.Vars, s.Ignored.Vars},
+		{"secrets", s.Managed.Secrets, s.Ignored.Secrets},
+		{"dependabot", s.Managed.Dependabot, s.Ignored.Dependabot},
+	}
+	for _, c := range conflicts {
+		for _, name := range c.ignored {
+			if _, ok := c.managed[name]; ok {
+				return fmt.Errorf("org %q: %q appears in both org.managed.%s and org.ignored.%s",
+					orgName, name, c.section, c.section)
+			}
+		}
+	}
+	return nil
+}
+
+func decodeOrgManaged(baseDir, orgName string, n *yaml.Node) (OrgManaged, error) {
+	var m OrgManaged
+	if n.Kind != yaml.MappingNode {
+		return m, fmt.Errorf("org %q: org.managed must be a mapping", orgName)
+	}
+	for i := 0; i < len(n.Content); i += 2 {
+		key := n.Content[i].Value
+		val := n.Content[i+1]
+		switch key {
+		case "vars":
+			es, err := decodeOrgEntries(baseDir, orgName, "vars", val)
+			if err != nil {
+				return m, err
+			}
+			m.Vars = es
+		case "secrets":
+			es, err := decodeOrgEntries(baseDir, orgName, "secrets", val)
+			if err != nil {
+				return m, err
+			}
+			m.Secrets = es
+		case "dependabot":
+			es, err := decodeOrgEntries(baseDir, orgName, "dependabot", val)
+			if err != nil {
+				return m, err
+			}
+			m.Dependabot = es
+		default:
+			return m, fmt.Errorf("org %q: org.managed: unknown key %q", orgName, key)
+		}
+	}
+	return m, nil
+}
+
+func decodeOrgEntries(baseDir, orgName, section string, n *yaml.Node) (map[string]*OrgEntry, error) {
+	if n.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("org %q: org.managed.%s must be a mapping", orgName, section)
+	}
+	out := map[string]*OrgEntry{}
+	for i := 0; i < len(n.Content); i += 2 {
+		name := n.Content[i].Value
+		val := n.Content[i+1]
+		if val.Kind != yaml.MappingNode {
+			return nil, fmt.Errorf("org %q: org.managed.%s.%s must use object form (got scalar)", orgName, section, name)
+		}
+		oe, err := decodeOrgEntry(baseDir, orgName, section, name, val)
+		if err != nil {
+			return nil, err
+		}
+		out[name] = oe
+	}
+	return out, nil
+}
+
+func decodeOrgEntry(baseDir, orgName, section, name string, n *yaml.Node) (*OrgEntry, error) {
+	e := &Entry{Name: name}
+	oe := &OrgEntry{Entry: e}
+	hasScope := false
+	for i := 0; i < len(n.Content); i += 2 {
+		k := n.Content[i].Value
+		v := n.Content[i+1]
+		switch k {
+		case "value":
+			e.HasValue = true
+			e.Value = v.Value
+		case "env":
+			e.Env = v.Value
+		case "file":
+			e.File = v.Value
+			if v.Value != "" {
+				if filepath.IsAbs(v.Value) {
+					e.FileAbs = filepath.Clean(v.Value)
+				} else {
+					e.FileAbs = filepath.Clean(filepath.Join(baseDir, v.Value))
+				}
+			}
+		case "scope":
+			hasScope = true
+			oe.Visibility = v.Value
+		case "repos":
+			list, err := decodeStringList(fmt.Sprintf("org %q", orgName), "org.managed."+section+"."+name+".repos", v)
+			if err != nil {
+				return nil, err
+			}
+			oe.Repos = list
+		default:
+			return nil, fmt.Errorf("org %q: org.managed.%s.%s: unknown key %q", orgName, section, name, k)
+		}
+	}
+	if err := validateEntrySources(fmt.Sprintf("org %q", orgName), "org.managed."+section, name, e); err != nil {
+		return nil, err
+	}
+	if !hasScope {
+		oe.Visibility = "all"
+	}
+	if err := validateOrgVisibility(orgName, section, name, oe); err != nil {
+		return nil, err
+	}
+	return oe, nil
+}
+
+func validateOrgVisibility(orgName, section, name string, oe *OrgEntry) error {
+	switch oe.Visibility {
+	case "all", "private":
+		if len(oe.Repos) > 0 {
+			return fmt.Errorf("org %q: org.managed.%s.%s: repos may only be set when scope is %q",
+				orgName, section, name, "selected")
+		}
+	case "selected":
+		if len(oe.Repos) == 0 {
+			return fmt.Errorf("org %q: org.managed.%s.%s: scope %q requires a non-empty repos list",
+				orgName, section, name, "selected")
+		}
+	default:
+		return fmt.Errorf("org %q: org.managed.%s.%s: scope must be one of all|private|selected (got %q)",
+			orgName, section, name, oe.Visibility)
+	}
+	return nil
 }
 
 func decodeRepo(baseDir, repoName string, n *yaml.Node) (*Repo, error) {
@@ -170,7 +371,7 @@ func decodeRepo(baseDir, repoName string, n *yaml.Node) (*Repo, error) {
 			}
 			repo.Managed = m
 		case "ignored":
-			ig, err := decodeIgnored(repoName, val)
+			ig, err := decodeIgnored(fmt.Sprintf("repo %q", repoName), val)
 			if err != nil {
 				return nil, err
 			}
@@ -284,13 +485,13 @@ func decodeEntry(baseDir, repoName, section, name string, n *yaml.Node) (*Entry,
 			return nil, fmt.Errorf("repo %q: managed.%s.%s: unknown key %q", repoName, section, name, k)
 		}
 	}
-	if err := validateEntrySources(repoName, section, name, e); err != nil {
+	if err := validateEntrySources(fmt.Sprintf("repo %q", repoName), "managed."+section, name, e); err != nil {
 		return nil, err
 	}
 	return e, nil
 }
 
-func validateEntrySources(repoName, section, name string, e *Entry) error {
+func validateEntrySources(ctx, section, name string, e *Entry) error {
 	count := 0
 	if e.HasValue {
 		count++
@@ -302,21 +503,21 @@ func validateEntrySources(repoName, section, name string, e *Entry) error {
 		count++
 	}
 	if count != 1 {
-		return fmt.Errorf("repo %q: managed.%s.%s: must set exactly one of value, env, file (got %d)",
-			repoName, section, name, count)
+		return fmt.Errorf("%s: %s.%s: must set exactly one of value, env, file (got %d)",
+			ctx, section, name, count)
 	}
 	return nil
 }
 
-func decodeIgnored(repoName string, n *yaml.Node) (Ignored, error) {
+func decodeIgnored(ctx string, n *yaml.Node) (Ignored, error) {
 	var ig Ignored
 	if n.Kind != yaml.MappingNode {
-		return ig, fmt.Errorf("repo %q: ignored must be a mapping", repoName)
+		return ig, fmt.Errorf("%s: ignored must be a mapping", ctx)
 	}
 	for i := 0; i < len(n.Content); i += 2 {
 		key := n.Content[i].Value
 		val := n.Content[i+1]
-		list, err := decodeStringList(repoName, "ignored."+key, val)
+		list, err := decodeStringList(ctx, "ignored."+key, val)
 		if err != nil {
 			return ig, err
 		}
@@ -328,20 +529,20 @@ func decodeIgnored(repoName string, n *yaml.Node) (Ignored, error) {
 		case "dependabot":
 			ig.Dependabot = list
 		default:
-			return ig, fmt.Errorf("repo %q: ignored: unknown key %q", repoName, key)
+			return ig, fmt.Errorf("%s: ignored: unknown key %q", ctx, key)
 		}
 	}
 	return ig, nil
 }
 
-func decodeStringList(repoName, ctx string, n *yaml.Node) ([]string, error) {
+func decodeStringList(ctx, what string, n *yaml.Node) ([]string, error) {
 	if n.Kind != yaml.SequenceNode {
-		return nil, fmt.Errorf("repo %q: %s must be a list of strings", repoName, ctx)
+		return nil, fmt.Errorf("%s: %s must be a list of strings", ctx, what)
 	}
 	out := make([]string, 0, len(n.Content))
 	for _, item := range n.Content {
 		if item.Kind != yaml.ScalarNode {
-			return nil, fmt.Errorf("repo %q: %s must be a list of strings", repoName, ctx)
+			return nil, fmt.Errorf("%s: %s must be a list of strings", ctx, what)
 		}
 		out = append(out, item.Value)
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -418,3 +418,258 @@ func TestLoadFile_Missing(t *testing.T) {
 func contains(ss []string, s string) bool {
 	return slices.Contains(ss, s)
 }
+
+func TestLoad_OrgScope_Valid(t *testing.T) {
+	t.Parallel()
+
+	const yml = `
+github.com:
+  example:
+    org:
+      managed:
+        vars:
+          ORG_VAR_ALL:
+            value: v
+          ORG_VAR_SEL:
+            value: w
+            scope: selected
+            repos:
+              - r1
+              - r2
+        secrets:
+          ORG_SEC:
+            value: s
+            scope: private
+        dependabot:
+          ORG_DEP:
+            env: ORG_DEP_VAR
+      ignored:
+        vars:
+          - IGNORED_ORG_VAR
+        secrets:
+          - IGNORED_ORG_SEC
+        dependabot:
+          - IGNORED_ORG_DEP
+`
+	cfg, err := LoadBytes([]byte(yml), "/c/secrets.yml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	org, ok := cfg.Org("example")
+	if !ok {
+		t.Fatalf("org example missing")
+	}
+	if org.OrgScope == nil {
+		t.Fatalf("OrgScope missing")
+	}
+	if got := org.OrgScope.Managed.Vars["ORG_VAR_ALL"]; got == nil {
+		t.Fatalf("ORG_VAR_ALL missing")
+	} else {
+		if got.Visibility != "all" {
+			t.Errorf("ORG_VAR_ALL visibility default: got %q want all", got.Visibility)
+		}
+		if got.Entry.Value != "v" {
+			t.Errorf("ORG_VAR_ALL value: got %q", got.Entry.Value)
+		}
+	}
+	sel := org.OrgScope.Managed.Vars["ORG_VAR_SEL"]
+	if sel == nil {
+		t.Fatalf("ORG_VAR_SEL missing")
+	}
+	if sel.Visibility != "selected" {
+		t.Errorf("ORG_VAR_SEL visibility: got %q", sel.Visibility)
+	}
+	if !equalStrings(sel.Repos, []string{"r1", "r2"}) {
+		t.Errorf("ORG_VAR_SEL repos: got %v", sel.Repos)
+	}
+	if v := org.OrgScope.Managed.Secrets["ORG_SEC"].Visibility; v != "private" {
+		t.Errorf("ORG_SEC visibility: got %q", v)
+	}
+	if v := org.OrgScope.Managed.Dependabot["ORG_DEP"].Entry.Env; v != "ORG_DEP_VAR" {
+		t.Errorf("ORG_DEP env: got %q", v)
+	}
+	if !contains(org.OrgScope.Ignored.Vars, "IGNORED_ORG_VAR") {
+		t.Errorf("ignored vars missing IGNORED_ORG_VAR: %v", org.OrgScope.Ignored.Vars)
+	}
+	if !contains(org.OrgScope.Ignored.Secrets, "IGNORED_ORG_SEC") {
+		t.Errorf("ignored secrets missing IGNORED_ORG_SEC")
+	}
+	if !contains(org.OrgScope.Ignored.Dependabot, "IGNORED_ORG_DEP") {
+		t.Errorf("ignored dependabot missing IGNORED_ORG_DEP")
+	}
+}
+
+func TestLoad_OrgScope_Invalid(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		yml       string
+		errSubstr string
+	}{
+		{
+			name: "selected without repos",
+			yml: `
+github.com:
+  example:
+    org:
+      managed:
+        vars:
+          V:
+            value: x
+            scope: selected
+`,
+			errSubstr: "selected",
+		},
+		{
+			name: "selected with empty repos",
+			yml: `
+github.com:
+  example:
+    org:
+      managed:
+        vars:
+          V:
+            value: x
+            scope: selected
+            repos: []
+`,
+			errSubstr: "selected",
+		},
+		{
+			name: "repos without selected",
+			yml: `
+github.com:
+  example:
+    org:
+      managed:
+        vars:
+          V:
+            value: x
+            scope: all
+            repos:
+              - r1
+`,
+			errSubstr: "repos",
+		},
+		{
+			name: "repos at default scope",
+			yml: `
+github.com:
+  example:
+    org:
+      managed:
+        vars:
+          V:
+            value: x
+            repos:
+              - r1
+`,
+			errSubstr: "repos",
+		},
+		{
+			name: "invalid scope value",
+			yml: `
+github.com:
+  example:
+    org:
+      managed:
+        vars:
+          V:
+            value: x
+            scope: bogus
+`,
+			errSubstr: "scope",
+		},
+		{
+			name: "unknown key in org entry",
+			yml: `
+github.com:
+  example:
+    org:
+      managed:
+        vars:
+          V:
+            value: x
+            bogus: 1
+`,
+			errSubstr: "unknown",
+		},
+		{
+			name: "unknown key in org block",
+			yml: `
+github.com:
+  example:
+    org:
+      bogus: {}
+`,
+			errSubstr: "unknown",
+		},
+		{
+			name: "scope on per-repo entry rejected",
+			yml: `
+github.com:
+  example:
+    per-repo:
+      acme:
+        managed:
+          vars:
+            V:
+              value: x
+              scope: all
+`,
+			errSubstr: "unknown",
+		},
+		{
+			name: "managed/ignored conflict in org",
+			yml: `
+github.com:
+  example:
+    org:
+      managed:
+        vars:
+          DUP:
+            value: x
+      ignored:
+        vars:
+          - DUP
+`,
+			errSubstr: "DUP",
+		},
+		{
+			name: "scalar shorthand in org",
+			yml: `
+github.com:
+  example:
+    org:
+      managed:
+        vars:
+          V: bar
+`,
+			errSubstr: "object form",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := LoadBytes([]byte(tc.yml), "/c/secrets.yml")
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.errSubstr)
+			}
+			if !strings.Contains(err.Error(), tc.errSubstr) {
+				t.Fatalf("error %q does not contain %q", err.Error(), tc.errSubstr)
+			}
+		})
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -34,6 +34,30 @@ type Backend interface {
 	DeleteRepoVariable(ctx context.Context, owner, repo, name string) error
 	DeleteRepoSecret(ctx context.Context, owner, repo, name string) error
 	DeleteRepoDependabotSecret(ctx context.Context, owner, repo, name string) error
+
+	// Org-level operations. Org secrets, variables, and Dependabot secrets
+	// are a different GitHub object class from their repo-level counterparts
+	// and use a separate public key for encryption.
+	ListOrgVariables(ctx context.Context, org string) (map[string]string, error)
+	ListOrgSecrets(ctx context.Context, org string) ([]string, error)
+	ListOrgDependabotSecrets(ctx context.Context, org string) ([]string, error)
+
+	GetOrgPublicKey(ctx context.Context, org string) (*PublicKey, error)
+	GetOrgDependabotPublicKey(ctx context.Context, org string) (*PublicKey, error)
+
+	SetOrgVariable(ctx context.Context, org, name, value, visibility string, selectedRepoIDs []int64) error
+	SetOrgSecret(ctx context.Context, org, name string, key *PublicKey, plaintext, visibility string, selectedRepoIDs []int64) error
+	SetOrgDependabotSecret(ctx context.Context, org, name string, key *PublicKey, plaintext, visibility string, selectedRepoIDs []int64) error
+
+	DeleteOrgVariable(ctx context.Context, org, name string) error
+	DeleteOrgSecret(ctx context.Context, org, name string) error
+	DeleteOrgDependabotSecret(ctx context.Context, org, name string) error
+
+	// GetRepoID resolves a repo name to its numeric GitHub ID. Used to
+	// translate `repos:` lists from configuration into the
+	// `selected_repository_ids` payload expected by the org-level secret
+	// and variable APIs.
+	GetRepoID(ctx context.Context, org, repo string) (int64, error)
 }
 
 // Client is the live GitHub backend.
@@ -215,6 +239,171 @@ func (c *Client) DeleteRepoDependabotSecret(ctx context.Context, owner, repo, na
 		return fmt.Errorf("delete repo dependabot secret %s: %w", name, err)
 	}
 	return nil
+}
+
+// ListOrgVariables returns org-level Actions variables as name → value map.
+func (c *Client) ListOrgVariables(ctx context.Context, org string) (map[string]string, error) {
+	vars, _, err := c.gh.Actions.ListOrgVariables(ctx, org, &gogithub.ListOptions{PerPage: 100})
+	if err != nil {
+		return nil, fmt.Errorf("list org variables: %w", err)
+	}
+	out := make(map[string]string, len(vars.Variables))
+	for _, v := range vars.Variables {
+		out[v.Name] = v.Value
+	}
+	return out, nil
+}
+
+// ListOrgSecrets returns the names of org-level Actions secrets.
+func (c *Client) ListOrgSecrets(ctx context.Context, org string) ([]string, error) {
+	secrets, _, err := c.gh.Actions.ListOrgSecrets(ctx, org, &gogithub.ListOptions{PerPage: 100})
+	if err != nil {
+		return nil, fmt.Errorf("list org secrets: %w", err)
+	}
+	return namesOf(secrets), nil
+}
+
+// ListOrgDependabotSecrets returns the names of org-level Dependabot secrets.
+func (c *Client) ListOrgDependabotSecrets(ctx context.Context, org string) ([]string, error) {
+	secrets, _, err := c.gh.Dependabot.ListOrgSecrets(ctx, org, &gogithub.ListOptions{PerPage: 100})
+	if err != nil {
+		return nil, fmt.Errorf("list org dependabot secrets: %w", err)
+	}
+	return namesOf(secrets), nil
+}
+
+// GetOrgPublicKey fetches the public key used to encrypt org Actions secrets.
+func (c *Client) GetOrgPublicKey(ctx context.Context, org string) (*PublicKey, error) {
+	pk, _, err := c.gh.Actions.GetOrgPublicKey(ctx, org)
+	if err != nil {
+		return nil, fmt.Errorf("get org actions public key: %w", err)
+	}
+	return toPublicKey(pk)
+}
+
+// GetOrgDependabotPublicKey fetches the public key used to encrypt org
+// Dependabot secrets.
+func (c *Client) GetOrgDependabotPublicKey(ctx context.Context, org string) (*PublicKey, error) {
+	pk, _, err := c.gh.Dependabot.GetOrgPublicKey(ctx, org)
+	if err != nil {
+		return nil, fmt.Errorf("get org dependabot public key: %w", err)
+	}
+	return toPublicKey(pk)
+}
+
+// SetOrgVariable creates or updates an org Actions variable with the given
+// visibility envelope. selectedRepoIDs must be non-empty when visibility is
+// "selected" and is ignored otherwise.
+func (c *Client) SetOrgVariable(ctx context.Context, org, name, value, visibility string, selectedRepoIDs []int64) error {
+	v := buildOrgVariable(name, value, visibility, selectedRepoIDs)
+	resp, err := c.gh.Actions.UpdateOrgVariable(ctx, org, v)
+	if err == nil {
+		return nil
+	}
+	if resp != nil && resp.StatusCode == 404 {
+		if _, cerr := c.gh.Actions.CreateOrgVariable(ctx, org, v); cerr != nil {
+			return fmt.Errorf("create org variable %s: %w", name, cerr)
+		}
+		return nil
+	}
+	return fmt.Errorf("update org variable %s: %w", name, err)
+}
+
+func buildOrgVariable(name, value, visibility string, selectedRepoIDs []int64) *gogithub.ActionsVariable {
+	v := &gogithub.ActionsVariable{Name: name, Value: value}
+	vis := visibility
+	v.Visibility = &vis
+	if visibility == "selected" {
+		ids := gogithub.SelectedRepoIDs(append([]int64(nil), selectedRepoIDs...))
+		v.SelectedRepositoryIDs = &ids
+	}
+	return v
+}
+
+// SetOrgSecret creates or updates an org Actions secret with the given
+// visibility envelope. plaintext is encrypted client-side with key.
+func (c *Client) SetOrgSecret(ctx context.Context, org, name string, key *PublicKey, plaintext, visibility string, selectedRepoIDs []int64) error {
+	if key == nil {
+		return fmt.Errorf("set org secret %s: missing public key", name)
+	}
+	enc, err := sealAnonymous(plaintext, key.Key)
+	if err != nil {
+		return fmt.Errorf("encrypt org secret %s: %w", name, err)
+	}
+	es := &gogithub.EncryptedSecret{
+		Name:           name,
+		KeyID:          key.KeyID,
+		EncryptedValue: enc,
+		Visibility:     visibility,
+	}
+	if visibility == "selected" {
+		es.SelectedRepositoryIDs = gogithub.SelectedRepoIDs(append([]int64(nil), selectedRepoIDs...))
+	}
+	if _, err := c.gh.Actions.CreateOrUpdateOrgSecret(ctx, org, es); err != nil {
+		return fmt.Errorf("set org secret %s: %w", name, err)
+	}
+	return nil
+}
+
+// SetOrgDependabotSecret creates or updates an org Dependabot secret with the
+// given visibility envelope.
+func (c *Client) SetOrgDependabotSecret(ctx context.Context, org, name string, key *PublicKey, plaintext, visibility string, selectedRepoIDs []int64) error {
+	if key == nil {
+		return fmt.Errorf("set org dependabot secret %s: missing public key", name)
+	}
+	enc, err := sealAnonymous(plaintext, key.Key)
+	if err != nil {
+		return fmt.Errorf("encrypt org dependabot secret %s: %w", name, err)
+	}
+	es := &gogithub.DependabotEncryptedSecret{
+		Name:           name,
+		KeyID:          key.KeyID,
+		EncryptedValue: enc,
+		Visibility:     visibility,
+	}
+	if visibility == "selected" {
+		es.SelectedRepositoryIDs = gogithub.DependabotSecretsSelectedRepoIDs(append([]int64(nil), selectedRepoIDs...))
+	}
+	if _, err := c.gh.Dependabot.CreateOrUpdateOrgSecret(ctx, org, es); err != nil {
+		return fmt.Errorf("set org dependabot secret %s: %w", name, err)
+	}
+	return nil
+}
+
+// DeleteOrgVariable deletes an org Actions variable.
+func (c *Client) DeleteOrgVariable(ctx context.Context, org, name string) error {
+	if _, err := c.gh.Actions.DeleteOrgVariable(ctx, org, name); err != nil {
+		return fmt.Errorf("delete org variable %s: %w", name, err)
+	}
+	return nil
+}
+
+// DeleteOrgSecret deletes an org Actions secret.
+func (c *Client) DeleteOrgSecret(ctx context.Context, org, name string) error {
+	if _, err := c.gh.Actions.DeleteOrgSecret(ctx, org, name); err != nil {
+		return fmt.Errorf("delete org secret %s: %w", name, err)
+	}
+	return nil
+}
+
+// DeleteOrgDependabotSecret deletes an org Dependabot secret.
+func (c *Client) DeleteOrgDependabotSecret(ctx context.Context, org, name string) error {
+	if _, err := c.gh.Dependabot.DeleteOrgSecret(ctx, org, name); err != nil {
+		return fmt.Errorf("delete org dependabot secret %s: %w", name, err)
+	}
+	return nil
+}
+
+// GetRepoID resolves a repo name to its numeric GitHub ID.
+func (c *Client) GetRepoID(ctx context.Context, org, repo string) (int64, error) {
+	r, _, err := c.gh.Repositories.Get(ctx, org, repo)
+	if err != nil {
+		return 0, fmt.Errorf("get repo %s/%s: %w", org, repo, err)
+	}
+	if r == nil || r.ID == nil {
+		return 0, fmt.Errorf("get repo %s/%s: missing id", org, repo)
+	}
+	return *r.ID, nil
 }
 
 func toPublicKey(pk *gogithub.PublicKey) (*PublicKey, error) {

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -309,11 +309,15 @@ func (c *Client) SetOrgVariable(ctx context.Context, org, name, value, visibilit
 	return fmt.Errorf("update org variable %s: %w", name, err)
 }
 
+// visibilitySelected names the only org-scope visibility value that takes a
+// selected_repository_ids payload.
+const visibilitySelected = "selected"
+
 func buildOrgVariable(name, value, visibility string, selectedRepoIDs []int64) *gogithub.ActionsVariable {
 	v := &gogithub.ActionsVariable{Name: name, Value: value}
 	vis := visibility
 	v.Visibility = &vis
-	if visibility == "selected" {
+	if visibility == visibilitySelected {
 		ids := gogithub.SelectedRepoIDs(append([]int64(nil), selectedRepoIDs...))
 		v.SelectedRepositoryIDs = &ids
 	}
@@ -336,7 +340,7 @@ func (c *Client) SetOrgSecret(ctx context.Context, org, name string, key *Public
 		EncryptedValue: enc,
 		Visibility:     visibility,
 	}
-	if visibility == "selected" {
+	if visibility == visibilitySelected {
 		es.SelectedRepositoryIDs = gogithub.SelectedRepoIDs(append([]int64(nil), selectedRepoIDs...))
 	}
 	if _, err := c.gh.Actions.CreateOrUpdateOrgSecret(ctx, org, es); err != nil {
@@ -361,7 +365,7 @@ func (c *Client) SetOrgDependabotSecret(ctx context.Context, org, name string, k
 		EncryptedValue: enc,
 		Visibility:     visibility,
 	}
-	if visibility == "selected" {
+	if visibility == visibilitySelected {
 		es.SelectedRepositoryIDs = gogithub.DependabotSecretsSelectedRepoIDs(append([]int64(nil), selectedRepoIDs...))
 	}
 	if _, err := c.gh.Dependabot.CreateOrUpdateOrgSecret(ctx, org, es); err != nil {

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -624,6 +624,537 @@ func decryptSealedBox(t *testing.T, encB64 string, pub, priv *[32]byte) string {
 	return string(out)
 }
 
+func TestClient_ListOrgVariables(t *testing.T) {
+	t.Parallel()
+	srv, c := newTestClient(t, map[string]string{
+		"/orgs/example/actions/variables": `{"total_count":2,"variables":[{"name":"V1","value":"one","visibility":"all"},{"name":"V2","value":"two","visibility":"private"}]}`,
+	})
+	defer srv.Close()
+
+	got, err := c.ListOrgVariables(context.Background(), "example")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got["V1"] != "one" || got["V2"] != "two" {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestClient_ListOrgVariables_Error(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"nope"}`, http.StatusForbidden)
+	}))
+	defer srv.Close()
+	c := newClientPointingAt(t, srv.URL)
+	if _, err := c.ListOrgVariables(context.Background(), "example"); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestClient_ListOrgSecrets(t *testing.T) {
+	t.Parallel()
+	srv, c := newTestClient(t, map[string]string{
+		"/orgs/example/actions/secrets": `{"total_count":1,"secrets":[{"name":"S1"}]}`, // #nosec G101 -- fixture
+	})
+	defer srv.Close()
+	got, err := c.ListOrgSecrets(context.Background(), "example")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0] != "S1" {
+		t.Fatalf("got %v", got)
+	}
+}
+
+func TestClient_ListOrgSecrets_Error(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"nope"}`, http.StatusForbidden)
+	}))
+	defer srv.Close()
+	c := newClientPointingAt(t, srv.URL)
+	if _, err := c.ListOrgSecrets(context.Background(), "example"); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestClient_ListOrgDependabotSecrets(t *testing.T) {
+	t.Parallel()
+	srv, c := newTestClient(t, map[string]string{
+		"/orgs/example/dependabot/secrets": `{"total_count":1,"secrets":[{"name":"D1"}]}`, // #nosec G101 -- fixture
+	})
+	defer srv.Close()
+	got, err := c.ListOrgDependabotSecrets(context.Background(), "example")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0] != "D1" {
+		t.Fatalf("got %v", got)
+	}
+}
+
+func TestClient_ListOrgDependabotSecrets_Error(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"nope"}`, http.StatusForbidden)
+	}))
+	defer srv.Close()
+	c := newClientPointingAt(t, srv.URL)
+	if _, err := c.ListOrgDependabotSecrets(context.Background(), "example"); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestClient_GetOrgPublicKeys(t *testing.T) {
+	t.Parallel()
+	srv, c := newTestClient(t, map[string]string{
+		"/orgs/example/actions/secrets/public-key":    `{"key_id":"org-act","key":"AAAA"}`, // #nosec G101 -- fixture
+		"/orgs/example/dependabot/secrets/public-key": `{"key_id":"org-dep","key":"BBBB"}`, // #nosec G101 -- fixture
+	})
+	defer srv.Close()
+	pk, err := c.GetOrgPublicKey(context.Background(), "example")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pk.KeyID != "org-act" || pk.Key != "AAAA" {
+		t.Fatalf("got %+v", pk)
+	}
+	pk2, err := c.GetOrgDependabotPublicKey(context.Background(), "example")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pk2.KeyID != "org-dep" {
+		t.Fatalf("got %+v", pk2)
+	}
+}
+
+func TestClient_GetOrgPublicKey_Error(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"nope"}`, http.StatusForbidden)
+	}))
+	defer srv.Close()
+	c := newClientPointingAt(t, srv.URL)
+	if _, err := c.GetOrgPublicKey(context.Background(), "example"); err == nil {
+		t.Fatal("expected error")
+	}
+	if _, err := c.GetOrgDependabotPublicKey(context.Background(), "example"); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestClient_SetOrgVariable_Update_AllVisibility(t *testing.T) {
+	t.Parallel()
+	var captured struct {
+		method, path string
+		body         map[string]any
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.method = r.Method
+		captured.path = r.URL.Path
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &captured.body)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+	c := newClientPointingAt(t, srv.URL)
+	if err := c.SetOrgVariable(context.Background(), "example", "V", "v", "all", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if captured.method != http.MethodPatch {
+		t.Errorf("method: %s", captured.method)
+	}
+	if captured.path != "/orgs/example/actions/variables/V" {
+		t.Errorf("path: %s", captured.path)
+	}
+	if captured.body["visibility"] != "all" {
+		t.Errorf("visibility: %v", captured.body["visibility"])
+	}
+	if _, ok := captured.body["selected_repository_ids"]; ok {
+		t.Errorf("selected_repository_ids should be omitted for non-selected visibility: %+v", captured.body)
+	}
+}
+
+func TestClient_SetOrgVariable_CreateFallback_Selected(t *testing.T) {
+	t.Parallel()
+	var (
+		mu       sync.Mutex
+		calls    []string
+		lastBody map[string]any
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		calls = append(calls, r.Method+" "+r.URL.Path)
+		if r.Method == http.MethodPatch {
+			http.Error(w, `{"message":"not found"}`, http.StatusNotFound)
+			return
+		}
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &lastBody)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+	c := newClientPointingAt(t, srv.URL)
+	if err := c.SetOrgVariable(context.Background(), "example", "V", "v", "selected", []int64{11, 22}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	wantCalls := []string{
+		"PATCH /orgs/example/actions/variables/V",
+		"POST /orgs/example/actions/variables",
+	}
+	if strings.Join(calls, "|") != strings.Join(wantCalls, "|") {
+		t.Errorf("calls: %v", calls)
+	}
+	if lastBody["visibility"] != "selected" {
+		t.Errorf("visibility: %v", lastBody["visibility"])
+	}
+	ids, _ := lastBody["selected_repository_ids"].([]any)
+	if len(ids) != 2 {
+		t.Errorf("ids: %+v", lastBody["selected_repository_ids"])
+	}
+}
+
+func TestClient_SetOrgVariable_UpdateError(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"server"}`, http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	c := newClientPointingAt(t, srv.URL)
+	if err := c.SetOrgVariable(context.Background(), "example", "V", "v", "all", nil); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestClient_SetOrgVariable_CreateError(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPatch {
+			http.Error(w, `{"message":"not found"}`, http.StatusNotFound)
+			return
+		}
+		http.Error(w, `{"message":"boom"}`, http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	c := newClientPointingAt(t, srv.URL)
+	if err := c.SetOrgVariable(context.Background(), "example", "V", "v", "all", nil); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestClient_SetOrgSecret_PrivateVisibility(t *testing.T) {
+	t.Parallel()
+	pub, priv := genBoxKeypair(t)
+	pubB64 := base64.StdEncoding.EncodeToString(pub[:])
+	var captured struct {
+		method, path string
+		body         map[string]any
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.method = r.Method
+		captured.path = r.URL.Path
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &captured.body)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+	c := newClientPointingAt(t, srv.URL)
+	err := c.SetOrgSecret(context.Background(), "example", "S",
+		&PublicKey{KeyID: "kid", Key: pubB64}, "plain", "private", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if captured.method != http.MethodPut {
+		t.Errorf("method: %s", captured.method)
+	}
+	if captured.path != "/orgs/example/actions/secrets/S" {
+		t.Errorf("path: %s", captured.path)
+	}
+	if captured.body["visibility"] != "private" {
+		t.Errorf("visibility: %v", captured.body["visibility"])
+	}
+	if _, ok := captured.body["selected_repository_ids"]; ok {
+		t.Errorf("selected_repository_ids should be omitted: %+v", captured.body)
+	}
+	enc, _ := captured.body["encrypted_value"].(string)
+	plain := decryptSealedBox(t, enc, pub, priv)
+	if plain != "plain" {
+		t.Errorf("decrypted: %q", plain)
+	}
+}
+
+func TestClient_SetOrgSecret_SelectedVisibility(t *testing.T) {
+	t.Parallel()
+	pub, _ := genBoxKeypair(t)
+	pubB64 := base64.StdEncoding.EncodeToString(pub[:])
+	var captured struct{ body map[string]any }
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &captured.body)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+	c := newClientPointingAt(t, srv.URL)
+	err := c.SetOrgSecret(context.Background(), "example", "S",
+		&PublicKey{KeyID: "kid", Key: pubB64}, "x", "selected", []int64{1, 2, 3})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if captured.body["visibility"] != "selected" {
+		t.Errorf("visibility: %v", captured.body["visibility"])
+	}
+	ids, _ := captured.body["selected_repository_ids"].([]any)
+	if len(ids) != 3 {
+		t.Errorf("ids: %v", captured.body["selected_repository_ids"])
+	}
+}
+
+func TestClient_SetOrgSecret_NilKey(t *testing.T) {
+	t.Parallel()
+	c := newClientPointingAt(t, "http://127.0.0.1:0")
+	if err := c.SetOrgSecret(context.Background(), "example", "S", nil, "v", "all", nil); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestClient_SetOrgSecret_BadKey(t *testing.T) {
+	t.Parallel()
+	c := newClientPointingAt(t, "http://127.0.0.1:0")
+	err := c.SetOrgSecret(context.Background(), "example", "S",
+		&PublicKey{KeyID: "kid", Key: "not-base64!!!"}, "v", "all", nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestClient_SetOrgSecret_APIError(t *testing.T) {
+	t.Parallel()
+	pub, _ := genBoxKeypair(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"nope"}`, http.StatusForbidden)
+	}))
+	defer srv.Close()
+	c := newClientPointingAt(t, srv.URL)
+	err := c.SetOrgSecret(context.Background(), "example", "S",
+		&PublicKey{KeyID: "kid", Key: base64.StdEncoding.EncodeToString(pub[:])}, "v", "all", nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestClient_SetOrgDependabotSecret_PrivateVisibility(t *testing.T) {
+	t.Parallel()
+	pub, _ := genBoxKeypair(t)
+	pubB64 := base64.StdEncoding.EncodeToString(pub[:])
+	var captured struct {
+		path string
+		body map[string]any
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.path = r.URL.Path
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &captured.body)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+	c := newClientPointingAt(t, srv.URL)
+	err := c.SetOrgDependabotSecret(context.Background(), "example", "D",
+		&PublicKey{KeyID: "kid-dep", Key: pubB64}, "v", "private", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if captured.path != "/orgs/example/dependabot/secrets/D" {
+		t.Errorf("path: %s", captured.path)
+	}
+	if captured.body["visibility"] != "private" {
+		t.Errorf("visibility: %v", captured.body["visibility"])
+	}
+}
+
+func TestClient_SetOrgDependabotSecret_SelectedVisibility(t *testing.T) {
+	t.Parallel()
+	pub, _ := genBoxKeypair(t)
+	pubB64 := base64.StdEncoding.EncodeToString(pub[:])
+	var captured struct{ body map[string]any }
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &captured.body)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+	c := newClientPointingAt(t, srv.URL)
+	err := c.SetOrgDependabotSecret(context.Background(), "example", "D",
+		&PublicKey{KeyID: "kid-dep", Key: pubB64}, "v", "selected", []int64{99})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ids, _ := captured.body["selected_repository_ids"].([]any)
+	if len(ids) != 1 {
+		t.Errorf("ids: %v", captured.body["selected_repository_ids"])
+	}
+}
+
+func TestClient_SetOrgDependabotSecret_NilKey(t *testing.T) {
+	t.Parallel()
+	c := newClientPointingAt(t, "http://127.0.0.1:0")
+	if err := c.SetOrgDependabotSecret(context.Background(), "example", "D", nil, "v", "all", nil); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestClient_SetOrgDependabotSecret_BadKey(t *testing.T) {
+	t.Parallel()
+	c := newClientPointingAt(t, "http://127.0.0.1:0")
+	err := c.SetOrgDependabotSecret(context.Background(), "example", "D",
+		&PublicKey{KeyID: "kid", Key: "not-base64!!!"}, "v", "all", nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestClient_SetOrgDependabotSecret_APIError(t *testing.T) {
+	t.Parallel()
+	pub, _ := genBoxKeypair(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"nope"}`, http.StatusForbidden)
+	}))
+	defer srv.Close()
+	c := newClientPointingAt(t, srv.URL)
+	err := c.SetOrgDependabotSecret(context.Background(), "example", "D",
+		&PublicKey{KeyID: "kid", Key: base64.StdEncoding.EncodeToString(pub[:])}, "v", "all", nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestClient_DeleteOrgVariable(t *testing.T) {
+	t.Parallel()
+	var captured struct{ method, path string }
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.method = r.Method
+		captured.path = r.URL.Path
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+	c := newClientPointingAt(t, srv.URL)
+	if err := c.DeleteOrgVariable(context.Background(), "example", "V"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if captured.method != http.MethodDelete || captured.path != "/orgs/example/actions/variables/V" {
+		t.Errorf("captured: %+v", captured)
+	}
+}
+
+func TestClient_DeleteOrgVariable_Error(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"nope"}`, http.StatusForbidden)
+	}))
+	defer srv.Close()
+	c := newClientPointingAt(t, srv.URL)
+	if err := c.DeleteOrgVariable(context.Background(), "example", "V"); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestClient_DeleteOrgSecret(t *testing.T) {
+	t.Parallel()
+	var captured struct{ path string }
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.path = r.URL.Path
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+	c := newClientPointingAt(t, srv.URL)
+	if err := c.DeleteOrgSecret(context.Background(), "example", "S"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if captured.path != "/orgs/example/actions/secrets/S" {
+		t.Errorf("path: %s", captured.path)
+	}
+}
+
+func TestClient_DeleteOrgSecret_Error(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"nope"}`, http.StatusForbidden)
+	}))
+	defer srv.Close()
+	c := newClientPointingAt(t, srv.URL)
+	if err := c.DeleteOrgSecret(context.Background(), "example", "S"); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestClient_DeleteOrgDependabotSecret(t *testing.T) {
+	t.Parallel()
+	var captured struct{ path string }
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.path = r.URL.Path
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+	c := newClientPointingAt(t, srv.URL)
+	if err := c.DeleteOrgDependabotSecret(context.Background(), "example", "D"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if captured.path != "/orgs/example/dependabot/secrets/D" {
+		t.Errorf("path: %s", captured.path)
+	}
+}
+
+func TestClient_DeleteOrgDependabotSecret_Error(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"nope"}`, http.StatusForbidden)
+	}))
+	defer srv.Close()
+	c := newClientPointingAt(t, srv.URL)
+	if err := c.DeleteOrgDependabotSecret(context.Background(), "example", "D"); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestClient_GetRepoID(t *testing.T) {
+	t.Parallel()
+	srv, c := newTestClient(t, map[string]string{
+		"/repos/example/acme": `{"id":12345,"name":"acme"}`,
+	})
+	defer srv.Close()
+	id, err := c.GetRepoID(context.Background(), "example", "acme")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != 12345 {
+		t.Errorf("got %d", id)
+	}
+}
+
+func TestClient_GetRepoID_Error(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"nope"}`, http.StatusNotFound)
+	}))
+	defer srv.Close()
+	c := newClientPointingAt(t, srv.URL)
+	if _, err := c.GetRepoID(context.Background(), "example", "acme"); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestClient_GetRepoID_MissingID(t *testing.T) {
+	t.Parallel()
+	srv, c := newTestClient(t, map[string]string{
+		"/repos/example/acme": `{"name":"acme"}`,
+	})
+	defer srv.Close()
+	if _, err := c.GetRepoID(context.Background(), "example", "acme"); err == nil {
+		t.Fatal("expected error for missing id")
+	}
+}
+
 func newTestClient(t *testing.T, responses map[string]string) (*httptest.Server, *Client) {
 	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -45,6 +45,19 @@ type Intent struct {
 	// all-repos.managed and the per-repo entry took precedence. Reserved for
 	// audit-side override reporting; runtime behavior is unaffected.
 	OverridesAllRepos bool
+
+	// IsOrg distinguishes an org-level intent (different GitHub object class)
+	// from a repo-level intent. When true, Repo is empty and the entry is
+	// targeted at the named organization.
+	IsOrg bool
+
+	// Visibility is the org-level secret/variable visibility envelope and is
+	// only meaningful when IsOrg is true. One of "all", "private", "selected".
+	Visibility string
+
+	// SelectedRepos is the static list of repo names that may access the
+	// entry; only populated when IsOrg && Visibility == "selected".
+	SelectedRepos []string
 }
 
 // ForRepo returns intents for every managed entry on the repo plus a
@@ -219,6 +232,74 @@ func stringSet(ss []string) map[string]struct{} {
 		out[s] = struct{}{}
 	}
 	return out
+}
+
+// ForOrg returns intents for an org-level scope.
+//
+// Org intents are a different GitHub object class than repo intents (org
+// secrets/vars/dependabot live on the organization, not on a repo) and are
+// therefore returned with IsOrg=true and Repo="". The cascade rules between
+// per-repo / all-repos / org operate on repo-level objects only — org-scope
+// intents do not collide with repo-scope intents.
+//
+// Output order is stable: section order vars, secrets, dependabot;
+// within each section, managed names sorted, then ignored names sorted.
+func ForOrg(s *config.OrgScope) []Intent {
+	if s == nil {
+		return nil
+	}
+	out := make([]Intent, 0)
+	out = appendOrgKind(out, KindVar, s.Managed.Vars, s.Ignored.Vars)
+	out = appendOrgKind(out, KindSecret, s.Managed.Secrets, s.Ignored.Secrets)
+	out = appendOrgKind(out, KindDependabot, s.Managed.Dependabot, s.Ignored.Dependabot)
+	return out
+}
+
+func appendOrgKind(out []Intent, kind Kind, m map[string]*config.OrgEntry, ignored []string) []Intent {
+	names := make([]string, 0, len(m))
+	for n := range m {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	for _, n := range names {
+		oe := m[n]
+		out = append(out, Intent{
+			Kind:          kind,
+			Name:          n,
+			Action:        ActionManaged,
+			Entry:         oe.Entry,
+			IsOrg:         true,
+			Visibility:    oe.Visibility,
+			SelectedRepos: append([]string(nil), oe.Repos...),
+		})
+	}
+	ig := append([]string(nil), ignored...)
+	sort.Strings(ig)
+	for _, n := range ig {
+		out = append(out, Intent{
+			Kind:   kind,
+			Name:   n,
+			Action: ActionIgnored,
+			IsOrg:  true,
+		})
+	}
+	return out
+}
+
+// EffectiveOrgIgnored returns the org-level ignored list (no cascade).
+//
+// Useful for downstream code that needs an ignored set for marking extras at
+// the org scope. Unlike repo-scope ignored, there is no cascade across scope
+// classes; org.ignored applies only to the org-level GitHub object.
+func EffectiveOrgIgnored(s *config.OrgScope) config.Ignored {
+	if s == nil {
+		return config.Ignored{}
+	}
+	return config.Ignored{
+		Vars:       append([]string(nil), s.Ignored.Vars...),
+		Secrets:    append([]string(nil), s.Ignored.Secrets...),
+		Dependabot: append([]string(nil), s.Ignored.Dependabot...),
+	}
 }
 
 // EffectiveIgnored returns the cascaded ignored list at a single repo.

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -4,6 +4,7 @@
 package plan
 
 import (
+	"slices"
 	"sort"
 	"testing"
 
@@ -436,13 +437,5 @@ func summarize(in []Intent) []string {
 }
 
 func equal(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
+	return slices.Equal(a, b)
 }

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -295,6 +295,129 @@ func sortedEqual(a, b []string) bool {
 	return equal(aa, bb)
 }
 
+func TestForOrg(t *testing.T) {
+	t.Parallel()
+	s := &config.OrgScope{
+		Managed: config.OrgManaged{
+			Vars: map[string]*config.OrgEntry{
+				"V_ALL": {
+					Entry:      &config.Entry{Name: "V_ALL", HasValue: true, Value: "vall"},
+					Visibility: "all",
+				},
+				"V_SEL": {
+					Entry:      &config.Entry{Name: "V_SEL", HasValue: true, Value: "vsel"},
+					Visibility: "selected",
+					Repos:      []string{"r1", "r2"},
+				},
+			},
+			Secrets: map[string]*config.OrgEntry{
+				"S_PRIV": {
+					Entry:      &config.Entry{Name: "S_PRIV", HasValue: true, Value: "x"},
+					Visibility: "private",
+				},
+			},
+			Dependabot: map[string]*config.OrgEntry{
+				"D1": {
+					Entry:      &config.Entry{Name: "D1", HasValue: true, Value: "d"},
+					Visibility: "all",
+				},
+			},
+		},
+		Ignored: config.Ignored{
+			Vars:       []string{"IGV"},
+			Secrets:    []string{"IGS"},
+			Dependabot: []string{"IGD"},
+		},
+	}
+	intents := ForOrg(s)
+
+	// Org intents must be distinct from repo intents: IsOrg=true, Repo="".
+	for _, in := range intents {
+		if !in.IsOrg {
+			t.Errorf("expected IsOrg=true on %+v", in)
+		}
+		if in.Repo != "" {
+			t.Errorf("expected empty Repo on %+v", in)
+		}
+	}
+
+	byName := map[string]Intent{}
+	for _, in := range intents {
+		byName[string(in.Kind)+"/"+in.Name] = in
+	}
+	if got := byName["vars/V_ALL"]; got.Visibility != "all" || got.Action != ActionManaged {
+		t.Errorf("V_ALL intent: %+v", got)
+	}
+	sel := byName["vars/V_SEL"]
+	if sel.Visibility != "selected" || !equal(sel.SelectedRepos, []string{"r1", "r2"}) {
+		t.Errorf("V_SEL intent: %+v", sel)
+	}
+	if got := byName["secrets/S_PRIV"]; got.Visibility != "private" {
+		t.Errorf("S_PRIV visibility: %q", got.Visibility)
+	}
+	if got := byName["vars/IGV"]; got.Action != ActionIgnored {
+		t.Errorf("IGV should be ignored: %+v", got)
+	}
+	if got := byName["dependabot/D1"]; got.Entry == nil || got.Entry.Value != "d" {
+		t.Errorf("D1 entry wrong: %+v", got)
+	}
+}
+
+func TestForOrg_NilOrEmpty(t *testing.T) {
+	t.Parallel()
+	if intents := ForOrg(nil); len(intents) != 0 {
+		t.Errorf("nil OrgScope: got %d intents", len(intents))
+	}
+	if intents := ForOrg(&config.OrgScope{}); len(intents) != 0 {
+		t.Errorf("empty OrgScope: got %d intents", len(intents))
+	}
+}
+
+func TestEffectiveOrgIgnored(t *testing.T) {
+	t.Parallel()
+	if got := EffectiveOrgIgnored(nil); len(got.Vars)+len(got.Secrets)+len(got.Dependabot) != 0 {
+		t.Errorf("nil scope should produce empty ignored: %+v", got)
+	}
+	s := &config.OrgScope{Ignored: config.Ignored{
+		Vars:       []string{"V"},
+		Secrets:    []string{"S"},
+		Dependabot: []string{"D"},
+	}}
+	got := EffectiveOrgIgnored(s)
+	if !equal(got.Vars, []string{"V"}) || !equal(got.Secrets, []string{"S"}) || !equal(got.Dependabot, []string{"D"}) {
+		t.Errorf("got %+v", got)
+	}
+}
+
+func TestForOrg_DistinctFromRepoIntents(t *testing.T) {
+	t.Parallel()
+	// Same name X on org-level vars and on repo-level vars must produce two
+	// intents that don't collide: one with IsOrg=true, one with IsOrg=false.
+	s := &config.OrgScope{
+		Managed: config.OrgManaged{
+			Vars: map[string]*config.OrgEntry{"X": {
+				Entry: &config.Entry{Name: "X", HasValue: true, Value: "org-x"}, Visibility: "all",
+			}},
+		},
+	}
+	repo := &config.Repo{
+		Managed: config.Managed{
+			Vars: map[string]*config.Entry{"X": {Name: "X", HasValue: true, Value: "repo-x"}},
+		},
+	}
+	orgIntents := ForOrg(s)
+	repoIntents := ForRepo("acme", repo)
+	if len(orgIntents) != 1 || !orgIntents[0].IsOrg {
+		t.Fatalf("org intents wrong: %+v", orgIntents)
+	}
+	if len(repoIntents) != 1 || repoIntents[0].IsOrg {
+		t.Fatalf("repo intents wrong: %+v", repoIntents)
+	}
+	if orgIntents[0].Entry.Value == repoIntents[0].Entry.Value {
+		t.Errorf("entries should be distinct; got same value %q", orgIntents[0].Entry.Value)
+	}
+}
+
 func TestForRepo_EmptyRepo(t *testing.T) {
 	t.Parallel()
 	intents := ForRepo("acme", &config.Repo{})

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -485,69 +485,388 @@ func runOrg(ctx context.Context, repos []string, concurrency int, out io.Writer,
 	return res
 }
 
-// Audit runs an audit across every repo in the org concurrently. Per-repo
-// errors are reported and the run continues. The final summary line counts
-// ok, skipped, and failed repos.
+// Audit runs an audit across the org-level scope (when configured) and every
+// repo in the org concurrently. Per-repo errors are reported and the run
+// continues. The final summary line counts ok, skipped, and failed repos.
 func Audit(ctx context.Context, cfg *config.Config, org string, backend gh.Backend, out io.Writer, showIgnored bool, opts OrgOptions) (OrgResult, error) {
 	o, ok := cfg.Org(org)
 	if !ok {
 		return OrgResult{}, fmt.Errorf("org %q not found in config", org)
 	}
+	res := OrgResult{}
+	if o.OrgScope != nil {
+		orgRes, err := AuditOrgScope(ctx, cfg, org, backend, out, showIgnored)
+		if err != nil {
+			fmt.Fprintf(out, "org: %s\nscope: org\n  ERROR: %v\n", org, err)
+			res.FailedRepos++
+		} else if orgRes.Drift {
+			res.Drift = true
+		}
+	}
 	repos, skipped, err := targetRepos(ctx, backend, o, org)
 	if err != nil {
 		return OrgResult{}, err
 	}
-	res := runOrg(ctx, repos, opts.Concurrency, out, func(repo string) repoWork {
+	r := runOrg(ctx, repos, opts.Concurrency, out, func(repo string) repoWork {
 		return func(ctx context.Context, buf *bytes.Buffer) (Result, error) {
 			return AuditRepo(ctx, cfg, org, repo, backend, buf, showIgnored)
 		}
 	})
-	res.SkippedRepos = skipped
+	mergeOrgResult(&res, r, skipped)
 	fmt.Fprintf(out, "summary: ok=%d skipped=%d failed=%d\n", res.OkRepos, res.SkippedRepos, res.FailedRepos)
 	return res, nil
 }
 
-// Apply runs apply across every repo in the org concurrently. Per-repo
-// errors are reported and the run continues; per-entry write failures are
-// summed into FailedEntries.
+func mergeOrgResult(dst *OrgResult, src OrgResult, skipped int) {
+	dst.OkRepos += src.OkRepos
+	dst.FailedRepos += src.FailedRepos
+	dst.FailedEntries += src.FailedEntries
+	dst.SkippedRepos += skipped
+	if src.Drift {
+		dst.Drift = true
+	}
+}
+
+// Apply runs apply across the org-level scope (when configured) and every
+// repo in the org concurrently. Per-repo errors are reported and the run
+// continues; per-entry write failures are summed into FailedEntries.
 func Apply(ctx context.Context, cfg *config.Config, org string, backend gh.Backend, out io.Writer, opts OrgOptions) (OrgResult, error) {
 	o, ok := cfg.Org(org)
 	if !ok {
 		return OrgResult{}, fmt.Errorf("org %q not found in config", org)
 	}
+	res := OrgResult{}
+	if o.OrgScope != nil {
+		orgRes, err := ApplyOrgScope(ctx, cfg, org, backend, out)
+		if err != nil {
+			fmt.Fprintf(out, "org: %s\nscope: org\n  ERROR: %v\n", org, err)
+			res.FailedRepos++
+		} else {
+			res.FailedEntries += orgRes.Failed
+		}
+	}
 	repos, skipped, err := targetRepos(ctx, backend, o, org)
 	if err != nil {
 		return OrgResult{}, err
 	}
-	res := runOrg(ctx, repos, opts.Concurrency, out, func(repo string) repoWork {
+	r := runOrg(ctx, repos, opts.Concurrency, out, func(repo string) repoWork {
 		return func(ctx context.Context, buf *bytes.Buffer) (Result, error) {
 			return ApplyRepo(ctx, cfg, org, repo, backend, buf)
 		}
 	})
-	res.SkippedRepos = skipped
+	mergeOrgResult(&res, r, skipped)
 	fmt.Fprintf(out, "summary: ok=%d skipped=%d failed=%d\n", res.OkRepos, res.SkippedRepos, res.FailedRepos)
 	return res, nil
 }
 
-// Enforce runs enforce across every repo in the org concurrently. The
-// provided opts are forwarded to each EnforceRepo call.
+// Enforce runs enforce across the org-level scope (when configured) and
+// every repo in the org concurrently. The provided opts are forwarded to
+// each EnforceRepo / EnforceOrgScope call.
 func Enforce(ctx context.Context, cfg *config.Config, org string, backend gh.Backend, out io.Writer, opts EnforceOptions) (OrgResult, error) {
 	o, ok := cfg.Org(org)
 	if !ok {
 		return OrgResult{}, fmt.Errorf("org %q not found in config", org)
 	}
+	res := OrgResult{}
+	if o.OrgScope != nil {
+		orgRes, err := EnforceOrgScope(ctx, cfg, org, backend, out, opts)
+		if err != nil {
+			fmt.Fprintf(out, "org: %s\nscope: org\n  ERROR: %v\n", org, err)
+			res.FailedRepos++
+		} else {
+			res.FailedEntries += orgRes.Failed
+		}
+	}
 	repos, skipped, err := targetRepos(ctx, backend, o, org)
 	if err != nil {
 		return OrgResult{}, err
 	}
-	res := runOrg(ctx, repos, opts.Concurrency, out, func(repo string) repoWork {
+	r := runOrg(ctx, repos, opts.Concurrency, out, func(repo string) repoWork {
 		return func(ctx context.Context, buf *bytes.Buffer) (Result, error) {
 			return EnforceRepo(ctx, cfg, org, repo, backend, buf, opts)
 		}
 	})
-	res.SkippedRepos = skipped
+	mergeOrgResult(&res, r, skipped)
 	fmt.Fprintf(out, "summary: ok=%d skipped=%d failed=%d\n", res.OkRepos, res.SkippedRepos, res.FailedRepos)
 	return res, nil
+}
+
+// AuditOrgScope audits the org-level secrets, variables, and Dependabot
+// secrets defined under the org's `org:` block. It writes a single labeled
+// stanza to out. If the config has no `org:` block for orgName, the call is
+// a no-op (zero-value Result, no stanza, no error).
+func AuditOrgScope(ctx context.Context, cfg *config.Config, orgName string, backend gh.Backend, out io.Writer, showIgnored bool) (Result, error) {
+	o, ok := cfg.Org(orgName)
+	if !ok {
+		return Result{}, fmt.Errorf("org %q not found in config", orgName)
+	}
+	if o.OrgScope == nil {
+		return Result{}, nil
+	}
+	intents := plan.ForOrg(o.OrgScope)
+	desiredVars, err := resolveVars(intents)
+	if err != nil {
+		return Result{}, err
+	}
+	live, err := fetchOrgLive(ctx, backend, orgName)
+	if err != nil {
+		return Result{}, err
+	}
+	effIgnored := plan.EffectiveOrgIgnored(o.OrgScope)
+	entries := diff.Compute("", intents, desiredVars, live, effIgnored)
+	writeOrgStanza(out, orgName, entries, showIgnored)
+	return Result{Drift: diff.HasDrift(entries)}, nil
+}
+
+func fetchOrgLive(ctx context.Context, backend gh.Backend, org string) (diff.Live, error) {
+	vars, err := backend.ListOrgVariables(ctx, org)
+	if err != nil {
+		return diff.Live{}, err
+	}
+	secrets, err := backend.ListOrgSecrets(ctx, org)
+	if err != nil {
+		return diff.Live{}, err
+	}
+	dependabot, err := backend.ListOrgDependabotSecrets(ctx, org)
+	if err != nil {
+		return diff.Live{}, err
+	}
+	return diff.Live{Vars: vars, Secrets: secrets, Dependabot: dependabot}, nil
+}
+
+func writeOrgStanza(out io.Writer, orgName string, entries []diff.Entry, showIgnored bool) {
+	fmt.Fprintf(out, "org: %s\nscope: org\n", orgName)
+	for _, e := range entries {
+		if e.Status == diff.Ignored && !showIgnored {
+			continue
+		}
+		switch e.Status {
+		case diff.Mismatch:
+			fmt.Fprintf(out, "  %s/%s: mismatch (yaml=%q live=%q)\n", e.Kind, e.Name, e.DesiredValue, e.LiveValue)
+		default:
+			fmt.Fprintf(out, "  %s/%s: %s\n", e.Kind, e.Name, e.Status)
+		}
+	}
+}
+
+// ApplyOrgScope writes org-level managed entries. It never deletes and never
+// touches anything outside the org's `org.managed` block. Returns Result with
+// per-entry write failures counted in Failed.
+func ApplyOrgScope(ctx context.Context, cfg *config.Config, orgName string, backend gh.Backend, out io.Writer) (Result, error) {
+	o, ok := cfg.Org(orgName)
+	if !ok {
+		return Result{}, fmt.Errorf("org %q not found in config", orgName)
+	}
+	if o.OrgScope == nil {
+		return Result{}, nil
+	}
+	intents := plan.ForOrg(o.OrgScope)
+	resolved, err := resolveAll(intents)
+	if err != nil {
+		return Result{}, err
+	}
+	idsByIntent, err := resolveSelectedRepoIDs(ctx, backend, orgName, intents)
+	if err != nil {
+		return Result{}, err
+	}
+	actionsKey, depKey, err := fetchOrgKeys(ctx, backend, orgName, intents)
+	if err != nil {
+		return Result{}, err
+	}
+	fmt.Fprintf(out, "org: %s\nscope: org\n", orgName)
+	res := Result{}
+	for _, in := range intents {
+		if in.Action != plan.ActionManaged {
+			continue
+		}
+		err := applyOrgOne(ctx, backend, orgName, in, resolved[entryKey(in)], idsByIntent[entryKey(in)], actionsKey, depKey)
+		if err != nil {
+			res.Failed++
+			fmt.Fprintf(out, "  %s/%s: FAILED: %v\n", in.Kind, in.Name, err)
+			continue
+		}
+		fmt.Fprintf(out, "  %s/%s: ok\n", in.Kind, in.Name)
+	}
+	if res.Failed > 0 {
+		fmt.Fprintf(out, "summary: %d failed\n", res.Failed)
+	}
+	return res, nil
+}
+
+func applyOrgOne(ctx context.Context, backend gh.Backend, org string, in plan.Intent, value string, ids []int64, actionsKey, depKey *gh.PublicKey) error {
+	switch in.Kind {
+	case plan.KindVar:
+		return backend.SetOrgVariable(ctx, org, in.Name, value, in.Visibility, ids)
+	case plan.KindSecret:
+		return backend.SetOrgSecret(ctx, org, in.Name, actionsKey, value, in.Visibility, ids)
+	case plan.KindDependabot:
+		return backend.SetOrgDependabotSecret(ctx, org, in.Name, depKey, value, in.Visibility, ids)
+	}
+	return fmt.Errorf("unknown kind %q", in.Kind)
+}
+
+func fetchOrgKeys(ctx context.Context, backend gh.Backend, org string, intents []plan.Intent) (actions, dependabot *gh.PublicKey, err error) {
+	needsActions, needsDep := false, false
+	for _, in := range intents {
+		if in.Action != plan.ActionManaged {
+			continue
+		}
+		switch in.Kind {
+		case plan.KindSecret:
+			needsActions = true
+		case plan.KindDependabot:
+			needsDep = true
+		}
+	}
+	if needsActions {
+		actions, err = backend.GetOrgPublicKey(ctx, org)
+		if err != nil {
+			return nil, nil, fmt.Errorf("fetch org actions public key: %w", err)
+		}
+	}
+	if needsDep {
+		dependabot, err = backend.GetOrgDependabotPublicKey(ctx, org)
+		if err != nil {
+			return nil, nil, fmt.Errorf("fetch org dependabot public key: %w", err)
+		}
+	}
+	return actions, dependabot, nil
+}
+
+// resolveSelectedRepoIDs translates each managed intent's `repos:` list into
+// a slice of numeric repo IDs. Names are looked up at most once per call,
+// even when multiple entries reference the same repo.
+func resolveSelectedRepoIDs(ctx context.Context, backend gh.Backend, org string, intents []plan.Intent) (map[string][]int64, error) {
+	out := map[string][]int64{}
+	cache := map[string]int64{}
+	for _, in := range intents {
+		if in.Action != plan.ActionManaged || in.Visibility != "selected" {
+			continue
+		}
+		ids := make([]int64, 0, len(in.SelectedRepos))
+		for _, name := range in.SelectedRepos {
+			id, ok := cache[name]
+			if !ok {
+				v, err := backend.GetRepoID(ctx, org, name)
+				if err != nil {
+					return nil, fmt.Errorf("resolve repo id %s/%s: %w", org, name, err)
+				}
+				cache[name] = v
+				id = v
+			}
+			ids = append(ids, id)
+		}
+		out[entryKey(in)] = ids
+	}
+	return out, nil
+}
+
+// EnforceOrgScope applies org-level managed entries, then deletes extras.
+//
+// With DryRun=true, no write API calls are made. Confirm is invoked exactly
+// once with the list of planned deletions; if it returns false, neither the
+// apply nor the delete phase runs.
+func EnforceOrgScope(ctx context.Context, cfg *config.Config, orgName string, backend gh.Backend, out io.Writer, opts EnforceOptions) (Result, error) {
+	o, ok := cfg.Org(orgName)
+	if !ok {
+		return Result{}, fmt.Errorf("org %q not found in config", orgName)
+	}
+	if o.OrgScope == nil {
+		return Result{}, nil
+	}
+	intents := plan.ForOrg(o.OrgScope)
+	resolved, err := resolveForEnforce(intents, opts.DryRun)
+	if err != nil {
+		return Result{}, err
+	}
+	live, err := fetchOrgLive(ctx, backend, orgName)
+	if err != nil {
+		return Result{}, err
+	}
+	effIgnored := plan.EffectiveOrgIgnored(o.OrgScope)
+	entries := diff.Compute("", intents, desiredVarsFromResolved(intents, resolved), live, effIgnored)
+
+	if !opts.DryRun && opts.Confirm != nil && !opts.Confirm(extraKindNames(entries)) {
+		return Result{}, nil
+	}
+
+	var (
+		idsByIntent map[string][]int64
+		actionsKey  *gh.PublicKey
+		depKey      *gh.PublicKey
+	)
+	if !opts.DryRun {
+		idsByIntent, err = resolveSelectedRepoIDs(ctx, backend, orgName, intents)
+		if err != nil {
+			return Result{}, err
+		}
+		actionsKey, depKey, err = fetchOrgKeys(ctx, backend, orgName, intents)
+		if err != nil {
+			return Result{}, err
+		}
+	}
+
+	fmt.Fprintf(out, "org: %s\nscope: org\n", orgName)
+	res := Result{}
+	res.Failed += runOrgApplyPhase(ctx, backend, orgName, intents, resolved, idsByIntent, actionsKey, depKey, out, opts.DryRun)
+	res.Failed += runOrgDeletePhase(ctx, backend, orgName, entries, out, opts.DryRun)
+	if res.Failed > 0 {
+		fmt.Fprintf(out, "summary: %d failed\n", res.Failed)
+	}
+	return res, nil
+}
+
+func runOrgApplyPhase(ctx context.Context, backend gh.Backend, org string, intents []plan.Intent, resolved map[string]string, idsByIntent map[string][]int64, actionsKey, depKey *gh.PublicKey, out io.Writer, dryRun bool) int {
+	failed := 0
+	for _, in := range intents {
+		if in.Action != plan.ActionManaged {
+			continue
+		}
+		if dryRun {
+			fmt.Fprintf(out, "  %s/%s: would-set\n", in.Kind, in.Name)
+			continue
+		}
+		err := applyOrgOne(ctx, backend, org, in, resolved[entryKey(in)], idsByIntent[entryKey(in)], actionsKey, depKey)
+		if err != nil {
+			failed++
+			fmt.Fprintf(out, "  %s/%s: FAILED: %v\n", in.Kind, in.Name, err)
+			continue
+		}
+		fmt.Fprintf(out, "  %s/%s: ok\n", in.Kind, in.Name)
+	}
+	return failed
+}
+
+func runOrgDeletePhase(ctx context.Context, backend gh.Backend, org string, entries []diff.Entry, out io.Writer, dryRun bool) int {
+	failed := 0
+	for _, e := range entries {
+		if e.Status != diff.Extra {
+			continue
+		}
+		if dryRun {
+			fmt.Fprintf(out, "  %s/%s: would-delete\n", e.Kind, e.Name)
+			continue
+		}
+		if err := deleteOrgOne(ctx, backend, org, e.Kind, e.Name); err != nil {
+			failed++
+			fmt.Fprintf(out, "  %s/%s: FAILED: %v\n", e.Kind, e.Name, err)
+			continue
+		}
+		fmt.Fprintf(out, "  %s/%s: deleted\n", e.Kind, e.Name)
+	}
+	return failed
+}
+
+func deleteOrgOne(ctx context.Context, backend gh.Backend, org string, kind plan.Kind, name string) error {
+	switch kind {
+	case plan.KindVar:
+		return backend.DeleteOrgVariable(ctx, org, name)
+	case plan.KindSecret:
+		return backend.DeleteOrgSecret(ctx, org, name)
+	case plan.KindDependabot:
+		return backend.DeleteOrgDependabotSecret(ctx, org, name)
+	}
+	return fmt.Errorf("unknown kind %q", kind)
 }
 
 // writeFile is a thin wrapper used by tests to materialize fixture YAML.

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -51,6 +51,36 @@ type fakeBackend struct {
 	setErr map[string]error
 	// delErr injects errors for specific (kind, name) pairs on delete.
 	delErr map[string]error
+
+	// Org-scope state.
+	orgVars       map[string]string
+	orgSecrets    []string
+	orgDependabot []string
+
+	orgActionsKeyErr     error
+	orgDependabotKeyErr  error
+	orgActionsKeyFetches int
+	orgDependabotKeyFetches int
+
+	setOrgVarCalls []setOrgVarCall
+	setOrgSecCalls []setOrgSecCall
+	setOrgDepCalls []setOrgSecCall
+	delOrgVarCalls []string
+	delOrgSecCalls []string
+	delOrgDepCalls []string
+
+	repoIDs    map[string]int64
+	repoIDsErr error
+}
+
+type setOrgVarCall struct {
+	name, value, visibility string
+	ids                     []int64
+}
+
+type setOrgSecCall struct {
+	name, plaintext, keyID, visibility string
+	ids                                []int64
 }
 
 type setVarCall struct {
@@ -171,6 +201,108 @@ func (f *fakeBackend) DeleteRepoDependabotSecret(_ context.Context, _, _, name s
 	}
 	f.delDepCalls = append(f.delDepCalls, name)
 	return nil
+}
+
+func (f *fakeBackend) ListOrgVariables(_ context.Context, _ string) (map[string]string, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.orgVars, nil
+}
+func (f *fakeBackend) ListOrgSecrets(_ context.Context, _ string) ([]string, error) {
+	return f.orgSecrets, f.err
+}
+func (f *fakeBackend) ListOrgDependabotSecrets(_ context.Context, _ string) ([]string, error) {
+	return f.orgDependabot, f.err
+}
+func (f *fakeBackend) GetOrgPublicKey(_ context.Context, _ string) (*gh.PublicKey, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.orgActionsKeyFetches++
+	if f.orgActionsKeyErr != nil {
+		return nil, f.orgActionsKeyErr
+	}
+	return &gh.PublicKey{KeyID: "key-org-actions", Key: "AAAA"}, nil
+}
+func (f *fakeBackend) GetOrgDependabotPublicKey(_ context.Context, _ string) (*gh.PublicKey, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.orgDependabotKeyFetches++
+	if f.orgDependabotKeyErr != nil {
+		return nil, f.orgDependabotKeyErr
+	}
+	return &gh.PublicKey{KeyID: "key-org-dep", Key: "BBBB"}, nil
+}
+func (f *fakeBackend) SetOrgVariable(_ context.Context, _, name, value, visibility string, ids []int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if e, ok := f.setErr["org/vars/"+name]; ok {
+		return e
+	}
+	f.setOrgVarCalls = append(f.setOrgVarCalls, setOrgVarCall{name, value, visibility, append([]int64(nil), ids...)})
+	return nil
+}
+func (f *fakeBackend) SetOrgSecret(_ context.Context, _, name string, key *gh.PublicKey, plaintext, visibility string, ids []int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if e, ok := f.setErr["org/secrets/"+name]; ok {
+		return e
+	}
+	keyID := ""
+	if key != nil {
+		keyID = key.KeyID
+	}
+	f.setOrgSecCalls = append(f.setOrgSecCalls, setOrgSecCall{name, plaintext, keyID, visibility, append([]int64(nil), ids...)})
+	return nil
+}
+func (f *fakeBackend) SetOrgDependabotSecret(_ context.Context, _, name string, key *gh.PublicKey, plaintext, visibility string, ids []int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if e, ok := f.setErr["org/dependabot/"+name]; ok {
+		return e
+	}
+	keyID := ""
+	if key != nil {
+		keyID = key.KeyID
+	}
+	f.setOrgDepCalls = append(f.setOrgDepCalls, setOrgSecCall{name, plaintext, keyID, visibility, append([]int64(nil), ids...)})
+	return nil
+}
+func (f *fakeBackend) DeleteOrgVariable(_ context.Context, _, name string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if e, ok := f.delErr["org/vars/"+name]; ok {
+		return e
+	}
+	f.delOrgVarCalls = append(f.delOrgVarCalls, name)
+	return nil
+}
+func (f *fakeBackend) DeleteOrgSecret(_ context.Context, _, name string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if e, ok := f.delErr["org/secrets/"+name]; ok {
+		return e
+	}
+	f.delOrgSecCalls = append(f.delOrgSecCalls, name)
+	return nil
+}
+func (f *fakeBackend) DeleteOrgDependabotSecret(_ context.Context, _, name string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if e, ok := f.delErr["org/dependabot/"+name]; ok {
+		return e
+	}
+	f.delOrgDepCalls = append(f.delOrgDepCalls, name)
+	return nil
+}
+func (f *fakeBackend) GetRepoID(_ context.Context, _, repo string) (int64, error) {
+	if f.repoIDsErr != nil {
+		return 0, f.repoIDsErr
+	}
+	if id, ok := f.repoIDs[repo]; ok {
+		return id, nil
+	}
+	return 0, errors.New("repo id not found: " + repo)
 }
 
 func TestAuditRepo_Drift(t *testing.T) {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -2175,6 +2175,485 @@ github.com:
 	}
 }
 
+func TestAuditOrgScope_NoOrgBlockIsNoop(t *testing.T) {
+	t.Parallel()
+	cfg := mustLoadCfg(t, `
+github.com:
+  example:
+    per-repo:
+      acme:
+        managed:
+          vars:
+            V:
+              value: ok
+`)
+	be := &fakeBackend{}
+	var out bytes.Buffer
+	res, err := AuditOrgScope(context.Background(), cfg, "example", be, &out, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Drift {
+		t.Errorf("no-op should not report drift")
+	}
+	if out.Len() != 0 {
+		t.Errorf("no-op should not write output: %q", out.String())
+	}
+}
+
+func TestAuditOrgScope_DriftFromMissingAndMismatch(t *testing.T) {
+	t.Parallel()
+	cfg := mustLoadCfg(t, `
+github.com:
+  example:
+    org:
+      managed:
+        vars:
+          V_OK:
+            value: same
+        secrets:
+          S_HERE:
+            value: x
+        dependabot:
+          D_GONE:
+            value: y
+`)
+	be := &fakeBackend{
+		orgVars:       map[string]string{"V_OK": "same", "EXTRA": "stray"},
+		orgSecrets:    []string{"S_HERE"},
+		orgDependabot: []string{},
+	}
+	var out bytes.Buffer
+	res, err := AuditOrgScope(context.Background(), cfg, "example", be, &out, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.Drift {
+		t.Errorf("expected drift (D_GONE missing, EXTRA extra)")
+	}
+	o := out.String()
+	if !strings.Contains(o, "org: example") || !strings.Contains(o, "scope: org") {
+		t.Errorf("missing stanza header: %q", o)
+	}
+	if !strings.Contains(o, "vars/V_OK: match") {
+		t.Errorf("V_OK should match: %q", o)
+	}
+	if !strings.Contains(o, "vars/EXTRA: extra") {
+		t.Errorf("EXTRA should be reported: %q", o)
+	}
+	if !strings.Contains(o, "dependabot/D_GONE: missing") {
+		t.Errorf("D_GONE should be missing: %q", o)
+	}
+}
+
+func TestAuditOrgScope_UnknownOrg(t *testing.T) {
+	t.Parallel()
+	cfg := mustLoadCfg(t, `github.com: {}`)
+	be := &fakeBackend{}
+	if _, err := AuditOrgScope(context.Background(), cfg, "ghost", be, &bytes.Buffer{}, false); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestAuditOrgScope_BackendError(t *testing.T) {
+	t.Parallel()
+	cfg := mustLoadCfg(t, `
+github.com:
+  example:
+    org:
+      managed:
+        vars:
+          V:
+            value: x
+`)
+	be := &fakeBackend{err: errors.New("boom")}
+	if _, err := AuditOrgScope(context.Background(), cfg, "example", be, &bytes.Buffer{}, false); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestApplyOrgScope_WritesVarsSecretsDependabot_WithVisibility(t *testing.T) {
+	t.Parallel()
+	cfg := mustLoadCfg(t, `
+github.com:
+  example:
+    org:
+      managed:
+        vars:
+          V_ALL:
+            value: vall
+          V_SEL:
+            value: vsel
+            scope: selected
+            repos:
+              - alpha
+              - beta
+        secrets:
+          S_PRIV:
+            value: secret
+            scope: private
+        dependabot:
+          D_ALL:
+            value: dep
+`)
+	be := &fakeBackend{
+		repoIDs: map[string]int64{"alpha": 1, "beta": 2},
+	}
+	var out bytes.Buffer
+	res, err := ApplyOrgScope(context.Background(), cfg, "example", be, &out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Failed != 0 {
+		t.Errorf("Failed=%d", res.Failed)
+	}
+	if be.orgActionsKeyFetches != 1 {
+		t.Errorf("expected exactly 1 org actions key fetch; got %d", be.orgActionsKeyFetches)
+	}
+	if be.orgDependabotKeyFetches != 1 {
+		t.Errorf("expected exactly 1 org dependabot key fetch; got %d", be.orgDependabotKeyFetches)
+	}
+	if len(be.setOrgVarCalls) != 2 {
+		t.Errorf("expected 2 var calls; got %d", len(be.setOrgVarCalls))
+	}
+	for _, c := range be.setOrgVarCalls {
+		switch c.name {
+		case "V_ALL":
+			if c.visibility != "all" || len(c.ids) != 0 {
+				t.Errorf("V_ALL: %+v", c)
+			}
+		case "V_SEL":
+			if c.visibility != "selected" || !slices.Equal(c.ids, []int64{1, 2}) {
+				t.Errorf("V_SEL: %+v", c)
+			}
+		}
+	}
+	if len(be.setOrgSecCalls) != 1 || be.setOrgSecCalls[0].visibility != "private" {
+		t.Errorf("expected one secret with private visibility: %+v", be.setOrgSecCalls)
+	}
+	if be.setOrgSecCalls[0].keyID != "key-org-actions" {
+		t.Errorf("secret should use org actions key: %+v", be.setOrgSecCalls[0])
+	}
+	if len(be.setOrgDepCalls) != 1 || be.setOrgDepCalls[0].keyID != "key-org-dep" {
+		t.Errorf("expected one dependabot secret using org dep key: %+v", be.setOrgDepCalls)
+	}
+	if !strings.Contains(out.String(), "scope: org") {
+		t.Errorf("output missing org-scope header: %q", out.String())
+	}
+}
+
+func TestApplyOrgScope_VarsOnly_NoKeyFetch(t *testing.T) {
+	t.Parallel()
+	cfg := mustLoadCfg(t, `
+github.com:
+  example:
+    org:
+      managed:
+        vars:
+          V:
+            value: x
+`)
+	be := &fakeBackend{}
+	if _, err := ApplyOrgScope(context.Background(), cfg, "example", be, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	if be.orgActionsKeyFetches != 0 || be.orgDependabotKeyFetches != 0 {
+		t.Errorf("expected no key fetches; actions=%d dep=%d",
+			be.orgActionsKeyFetches, be.orgDependabotKeyFetches)
+	}
+}
+
+func TestApplyOrgScope_RepoIDLookupError(t *testing.T) {
+	t.Parallel()
+	cfg := mustLoadCfg(t, `
+github.com:
+  example:
+    org:
+      managed:
+        vars:
+          V:
+            value: x
+            scope: selected
+            repos:
+              - missing
+`)
+	be := &fakeBackend{repoIDs: map[string]int64{}}
+	if _, err := ApplyOrgScope(context.Background(), cfg, "example", be, &bytes.Buffer{}); err == nil {
+		t.Fatal("expected error from repo id lookup")
+	}
+}
+
+func TestApplyOrgScope_PerEntryFailureContinues(t *testing.T) {
+	t.Parallel()
+	cfg := mustLoadCfg(t, `
+github.com:
+  example:
+    org:
+      managed:
+        vars:
+          V_OK:
+            value: x
+          V_BAD:
+            value: y
+`)
+	be := &fakeBackend{
+		setErr: map[string]error{"org/vars/V_BAD": errors.New("boom")},
+	}
+	var out bytes.Buffer
+	res, err := ApplyOrgScope(context.Background(), cfg, "example", be, &out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Failed != 1 {
+		t.Errorf("Failed=%d want 1", res.Failed)
+	}
+	if !strings.Contains(out.String(), "vars/V_BAD: FAILED") {
+		t.Errorf("output missing FAILED: %q", out.String())
+	}
+}
+
+func TestApplyOrgScope_NoOrgBlockIsNoop(t *testing.T) {
+	t.Parallel()
+	cfg := mustLoadCfg(t, `github.com: {example: {}}`)
+	be := &fakeBackend{}
+	var out bytes.Buffer
+	if _, err := ApplyOrgScope(context.Background(), cfg, "example", be, &out); err != nil {
+		t.Fatal(err)
+	}
+	if out.Len() != 0 {
+		t.Errorf("expected no output; got %q", out.String())
+	}
+}
+
+func TestApplyOrgScope_UnknownOrg(t *testing.T) {
+	t.Parallel()
+	cfg := mustLoadCfg(t, `github.com: {}`)
+	if _, err := ApplyOrgScope(context.Background(), cfg, "ghost", &fakeBackend{}, &bytes.Buffer{}); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestEnforceOrgScope_DeletesExtras(t *testing.T) {
+	t.Parallel()
+	cfg := mustLoadCfg(t, `
+github.com:
+  example:
+    org:
+      managed:
+        vars:
+          KEEP:
+            value: k
+      ignored:
+        vars:
+          - LEAVE
+`)
+	be := &fakeBackend{
+		orgVars: map[string]string{"KEEP": "k", "EXTRA": "drop", "LEAVE": "alone"},
+	}
+	var out bytes.Buffer
+	res, err := EnforceOrgScope(context.Background(), cfg, "example", be, &out, EnforceOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Failed != 0 {
+		t.Errorf("Failed=%d", res.Failed)
+	}
+	if !slices.Contains(be.delOrgVarCalls, "EXTRA") {
+		t.Errorf("EXTRA should have been deleted; got %v", be.delOrgVarCalls)
+	}
+	if slices.Contains(be.delOrgVarCalls, "LEAVE") {
+		t.Errorf("LEAVE is ignored; should not be deleted: %v", be.delOrgVarCalls)
+	}
+	if !strings.Contains(out.String(), "vars/EXTRA: deleted") {
+		t.Errorf("output missing deletion: %q", out.String())
+	}
+}
+
+func TestEnforceOrgScope_DryRunSkipsAllWrites(t *testing.T) {
+	t.Parallel()
+	cfg := mustLoadCfg(t, `
+github.com:
+  example:
+    org:
+      managed:
+        vars:
+          V:
+            value: x
+`)
+	be := &fakeBackend{orgVars: map[string]string{"EXTRA": "y"}}
+	var out bytes.Buffer
+	if _, err := EnforceOrgScope(context.Background(), cfg, "example", be, &out, EnforceOptions{DryRun: true}); err != nil {
+		t.Fatal(err)
+	}
+	if len(be.setOrgVarCalls) != 0 || len(be.delOrgVarCalls) != 0 {
+		t.Errorf("dry-run should not write or delete; calls set=%v del=%v",
+			be.setOrgVarCalls, be.delOrgVarCalls)
+	}
+	if !strings.Contains(out.String(), "would-set") || !strings.Contains(out.String(), "would-delete") {
+		t.Errorf("dry-run output missing markers: %q", out.String())
+	}
+}
+
+func TestEnforceOrgScope_ConfirmFalseSkipsWrites(t *testing.T) {
+	t.Parallel()
+	cfg := mustLoadCfg(t, `
+github.com:
+  example:
+    org:
+      managed:
+        vars:
+          V:
+            value: x
+`)
+	be := &fakeBackend{orgVars: map[string]string{"EXTRA": "y"}}
+	calls := 0
+	confirm := func(extras []string) bool {
+		calls++
+		if !slices.Contains(extras, "vars/EXTRA") {
+			t.Errorf("confirm should receive EXTRA; got %v", extras)
+		}
+		return false
+	}
+	if _, err := EnforceOrgScope(context.Background(), cfg, "example", be, &bytes.Buffer{}, EnforceOptions{Confirm: confirm}); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 {
+		t.Errorf("Confirm called %d times; want 1", calls)
+	}
+	if len(be.delOrgVarCalls) != 0 || len(be.setOrgVarCalls) != 0 {
+		t.Errorf("denied confirm should suppress writes; got set=%v del=%v",
+			be.setOrgVarCalls, be.delOrgVarCalls)
+	}
+}
+
+func TestEnforceOrgScope_NoOrgBlock(t *testing.T) {
+	t.Parallel()
+	cfg := mustLoadCfg(t, `github.com: {example: {}}`)
+	be := &fakeBackend{}
+	var out bytes.Buffer
+	if _, err := EnforceOrgScope(context.Background(), cfg, "example", be, &out, EnforceOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	if out.Len() != 0 {
+		t.Errorf("expected no output; got %q", out.String())
+	}
+}
+
+func TestEnforceOrgScope_UnknownOrg(t *testing.T) {
+	t.Parallel()
+	cfg := mustLoadCfg(t, `github.com: {}`)
+	if _, err := EnforceOrgScope(context.Background(), cfg, "ghost", &fakeBackend{}, &bytes.Buffer{}, EnforceOptions{}); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestAudit_IncludesOrgScopeStanza(t *testing.T) {
+	t.Parallel()
+	cfg := mustLoadCfg(t, `
+github.com:
+  example:
+    org:
+      managed:
+        vars:
+          ORG_VAR:
+            value: x
+    per-repo:
+      acme:
+        managed:
+          vars:
+            REPO_VAR:
+              value: y
+`)
+	be := &fakeBackend{
+		orgRepos: []string{"acme"},
+		vars:     map[string]string{"REPO_VAR": "y"},
+		orgVars:  map[string]string{"ORG_VAR": "x"},
+	}
+	var out bytes.Buffer
+	res, err := Audit(context.Background(), cfg, "example", be, &out, false, OrgOptions{Concurrency: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Drift {
+		t.Errorf("expected no drift")
+	}
+	o := out.String()
+	if !strings.Contains(o, "scope: org") {
+		t.Errorf("output missing org scope stanza: %q", o)
+	}
+	if !strings.Contains(o, "repo: acme") {
+		t.Errorf("output missing repo stanza: %q", o)
+	}
+}
+
+func TestApply_IncludesOrgScope(t *testing.T) {
+	t.Parallel()
+	cfg := mustLoadCfg(t, `
+github.com:
+  example:
+    org:
+      managed:
+        vars:
+          ORG_VAR:
+            value: x
+    per-repo:
+      acme:
+        managed:
+          vars:
+            REPO_VAR:
+              value: y
+`)
+	be := &fakeBackend{orgRepos: []string{"acme"}}
+	var out bytes.Buffer
+	if _, err := Apply(context.Background(), cfg, "example", be, &out, OrgOptions{Concurrency: 1}); err != nil {
+		t.Fatal(err)
+	}
+	if len(be.setOrgVarCalls) != 1 || be.setOrgVarCalls[0].name != "ORG_VAR" {
+		t.Errorf("expected ORG_VAR set call; got %+v", be.setOrgVarCalls)
+	}
+	if len(be.setVarCalls) != 1 || be.setVarCalls[0].name != "REPO_VAR" {
+		t.Errorf("expected REPO_VAR set call; got %+v", be.setVarCalls)
+	}
+}
+
+func TestEnforce_IncludesOrgScope(t *testing.T) {
+	t.Parallel()
+	cfg := mustLoadCfg(t, `
+github.com:
+  example:
+    org:
+      managed:
+        vars:
+          KEEP:
+            value: k
+`)
+	be := &fakeBackend{
+		orgRepos: []string{},
+		orgVars:  map[string]string{"KEEP": "k", "EXTRA": "drop"},
+	}
+	var out bytes.Buffer
+	if _, err := Enforce(context.Background(), cfg, "example", be, &out, EnforceOptions{Concurrency: 1}); err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Contains(be.delOrgVarCalls, "EXTRA") {
+		t.Errorf("expected EXTRA org-level delete: %v", be.delOrgVarCalls)
+	}
+}
+
+func mustLoadCfg(t *testing.T, body string) *config.Config {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "secrets.yml")
+	if err := writeFile(p, []byte(body)); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cfg
+}
+
 func TestEnforce_AtomicOutputDryRun(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()


### PR DESCRIPTION
Fixes #10

Adds the `org:` scope to the YAML schema and threads it through the
config, plan, github, and runner modules.

## Summary
- `config`: new `Org.OrgScope` parses `org.managed.{vars,secrets,dependabot}` and `org.ignored.*`. Each managed entry takes `scope: all|private|selected` (default `all`) plus `repos:`, validated together (selected requires repos; all/private rejects them).
- `plan`: `ForOrg` produces intents marked `IsOrg=true` with the visibility envelope. Org and repo intents are separate target classes.
- `github`: `Backend` gains list/set/delete for org Actions secrets, org Actions variables, and org Dependabot secrets, plus `GetOrgPublicKey`, `GetOrgDependabotPublicKey`, and `GetRepoID`. Org-secret encryption uses the org-level public key.
- `runner`: `AuditOrgScope`, `ApplyOrgScope`, `EnforceOrgScope` operate on the org scope; the org-wide `Audit`/`Apply`/`Enforce` entry points run the org-scope phase before iterating repos. Selected-visibility entries resolve repo names to numeric IDs once per call.
- `cli`: existing org-wide subcommands now exercise org scope automatically when configured. Smoke tests cover `audit` and `apply`.

## Test plan
- [x] `go test ./...` (all green)
- [x] `go test ./... -cover` (>=80% per package; lowest is config at 89.8%)
- [x] `golangci-lint run` (no issues)
- [x] Per-module tests: config visibility/scope/repos cross-checks; plan org intents distinct; github org endpoints with visibility payload via httptest; runner org-scope audit/apply/enforce paths plus per-entry failure handling.