### PR TITLE
audit: surface --show-ignored and override rows

### DIFF
--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -81,169 +81,170 @@ func Compute(repo string, intents []plan.Intent, desiredVars map[string]string, 
 	return out
 }
 
-func computeVars(repo string, intents []plan.Intent, desiredVars map[string]string, live Live, ignored config.Ignored) []Entry {
-	intended := map[string]struct{}{}
-	managedOverride := map[string]struct{}{}
-	ignoredShield := map[string]struct{}{}
-	out := make([]Entry, 0)
-	intentNames := make([]string, 0)
-	for _, in := range intents {
-		if in.Kind != plan.KindVar {
-			continue
-		}
-		switch in.Action {
-		case plan.ActionManaged:
-			intended[in.Name] = struct{}{}
-			intentNames = append(intentNames, in.Name)
-			if in.OverridesAllRepos {
-				managedOverride[in.Name] = struct{}{}
-			}
-		case plan.ActionIgnored:
-			if in.ShieldsAllReposManaged {
-				ignoredShield[in.Name] = struct{}{}
-			}
-		}
-	}
-	sort.Strings(intentNames)
-
-	for _, name := range intentNames {
-		desired := desiredVars[name]
-		e := Entry{Repo: repo, Kind: plan.KindVar, Name: name}
-		if _, ok := managedOverride[name]; ok {
-			e.Override = OverrideManaged
-		}
-		if liveVal, ok := live.Vars[name]; ok {
-			e.Status = Match
-			if liveVal != desired {
-				e.Status = Mismatch
-				e.DesiredValue = desired
-				e.LiveValue = liveVal
-			}
-		} else {
-			e.Status = Missing
-		}
-		out = append(out, e)
-	}
-
-	liveNames := make([]string, 0, len(live.Vars))
-	for n := range live.Vars {
-		liveNames = append(liveNames, n)
-	}
-	sort.Strings(liveNames)
-	emittedShield := map[string]struct{}{}
-	for _, name := range liveNames {
-		if _, ok := intended[name]; ok {
-			continue
-		}
-		e := Entry{Repo: repo, Kind: plan.KindVar, Name: name, Status: Extra}
-		if slices.Contains(ignored.Vars, name) {
-			e.Status = Ignored
-			if _, shielded := ignoredShield[name]; shielded {
-				e.Override = OverrideIgnored
-				emittedShield[name] = struct{}{}
-			}
-		}
-		out = append(out, e)
-	}
-	// Emit shield-override rows for names that were not on the live target.
-	// The override is a configuration-level fact (per-repo.ignored shielded
-	// all-repos.managed) and is meaningful regardless of live presence.
-	shieldNames := make([]string, 0)
-	for name := range ignoredShield {
-		if _, ok := emittedShield[name]; ok {
-			continue
-		}
-		shieldNames = append(shieldNames, name)
-	}
-	sort.Strings(shieldNames)
-	for _, name := range shieldNames {
-		out = append(out, Entry{
-			Repo:     repo,
-			Kind:     plan.KindVar,
-			Name:     name,
-			Status:   Ignored,
-			Override: OverrideIgnored,
-		})
-	}
-	return out
+// intentSets summarizes managed and ignored intents for one kind into the
+// lookup maps the diff loops need.
+type intentSets struct {
+	intended        map[string]struct{}
+	intentNames     []string
+	managedOverride map[string]struct{}
+	ignoredShield   map[string]struct{}
 }
 
-func computeNames(repo string, kind plan.Kind, intents []plan.Intent, liveNames []string, ignored []string) []Entry {
-	intended := map[string]struct{}{}
-	managedOverride := map[string]struct{}{}
-	ignoredShield := map[string]struct{}{}
-	out := make([]Entry, 0)
-	intentNames := make([]string, 0)
+func collectIntents(intents []plan.Intent, kind plan.Kind) intentSets {
+	s := intentSets{
+		intended:        map[string]struct{}{},
+		managedOverride: map[string]struct{}{},
+		ignoredShield:   map[string]struct{}{},
+		intentNames:     make([]string, 0),
+	}
 	for _, in := range intents {
 		if in.Kind != kind {
 			continue
 		}
 		switch in.Action {
 		case plan.ActionManaged:
-			intended[in.Name] = struct{}{}
-			intentNames = append(intentNames, in.Name)
+			s.intended[in.Name] = struct{}{}
+			s.intentNames = append(s.intentNames, in.Name)
 			if in.OverridesAllRepos {
-				managedOverride[in.Name] = struct{}{}
+				s.managedOverride[in.Name] = struct{}{}
 			}
 		case plan.ActionIgnored:
 			if in.ShieldsAllReposManaged {
-				ignoredShield[in.Name] = struct{}{}
+				s.ignoredShield[in.Name] = struct{}{}
 			}
 		}
 	}
-	sort.Strings(intentNames)
+	sort.Strings(s.intentNames)
+	return s
+}
+
+// shieldOnlyNames returns ignored-shield names that have not yet been
+// emitted via the live-state pass; these still need rows because the
+// override is a configuration-level fact.
+func shieldOnlyNames(shields, emitted map[string]struct{}) []string {
+	out := make([]string, 0)
+	for name := range shields {
+		if _, ok := emitted[name]; ok {
+			continue
+		}
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func computeVars(repo string, intents []plan.Intent, desiredVars map[string]string, live Live, ignored config.Ignored) []Entry {
+	s := collectIntents(intents, plan.KindVar)
+	out := make([]Entry, 0)
+
+	for _, name := range s.intentNames {
+		out = append(out, varEntry(repo, name, desiredVars[name], live.Vars, s.managedOverride))
+	}
+
+	liveNames := sortedKeys(live.Vars)
+	emittedShield := map[string]struct{}{}
+	for _, name := range liveNames {
+		if _, ok := s.intended[name]; ok {
+			continue
+		}
+		out = append(out, extraVarEntry(repo, name, ignored.Vars, s.ignoredShield, emittedShield))
+	}
+	for _, name := range shieldOnlyNames(s.ignoredShield, emittedShield) {
+		out = append(out, Entry{Repo: repo, Kind: plan.KindVar, Name: name, Status: Ignored, Override: OverrideIgnored})
+	}
+	return out
+}
+
+func varEntry(repo, name, desired string, liveVars map[string]string, managedOverride map[string]struct{}) Entry {
+	e := Entry{Repo: repo, Kind: plan.KindVar, Name: name}
+	if _, ok := managedOverride[name]; ok {
+		e.Override = OverrideManaged
+	}
+	if liveVal, ok := liveVars[name]; ok {
+		e.Status = Match
+		if liveVal != desired {
+			e.Status = Mismatch
+			e.DesiredValue = desired
+			e.LiveValue = liveVal
+		}
+	} else {
+		e.Status = Missing
+	}
+	return e
+}
+
+func extraVarEntry(repo, name string, ignored []string, shield, emitted map[string]struct{}) Entry {
+	e := Entry{Repo: repo, Kind: plan.KindVar, Name: name, Status: Extra}
+	if !slices.Contains(ignored, name) {
+		return e
+	}
+	e.Status = Ignored
+	if _, shielded := shield[name]; shielded {
+		e.Override = OverrideIgnored
+		emitted[name] = struct{}{}
+	}
+	return e
+}
+
+func sortedKeys(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for n := range m {
+		out = append(out, n)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func computeNames(repo string, kind plan.Kind, intents []plan.Intent, liveNames []string, ignored []string) []Entry {
+	s := collectIntents(intents, kind)
+	out := make([]Entry, 0)
 	liveSet := map[string]struct{}{}
 	for _, n := range liveNames {
 		liveSet[n] = struct{}{}
 	}
 
-	for _, name := range intentNames {
-		e := Entry{Repo: repo, Kind: kind, Name: name}
-		if _, ok := managedOverride[name]; ok {
-			e.Override = OverrideManaged
-		}
-		if _, ok := liveSet[name]; ok {
-			e.Status = Present
-		} else {
-			e.Status = Missing
-		}
-		out = append(out, e)
+	for _, name := range s.intentNames {
+		out = append(out, nameEntry(repo, kind, name, liveSet, s.managedOverride))
 	}
 	sortedLive := append([]string(nil), liveNames...)
 	sort.Strings(sortedLive)
 	emittedShield := map[string]struct{}{}
 	for _, name := range sortedLive {
-		if _, ok := intended[name]; ok {
+		if _, ok := s.intended[name]; ok {
 			continue
 		}
-		e := Entry{Repo: repo, Kind: kind, Name: name, Status: Extra}
-		if slices.Contains(ignored, name) {
-			e.Status = Ignored
-			if _, shielded := ignoredShield[name]; shielded {
-				e.Override = OverrideIgnored
-				emittedShield[name] = struct{}{}
-			}
-		}
-		out = append(out, e)
+		out = append(out, extraNameEntry(repo, kind, name, ignored, s.ignoredShield, emittedShield))
 	}
-	shieldNames := make([]string, 0)
-	for name := range ignoredShield {
-		if _, ok := emittedShield[name]; ok {
-			continue
-		}
-		shieldNames = append(shieldNames, name)
-	}
-	sort.Strings(shieldNames)
-	for _, name := range shieldNames {
-		out = append(out, Entry{
-			Repo:     repo,
-			Kind:     kind,
-			Name:     name,
-			Status:   Ignored,
-			Override: OverrideIgnored,
-		})
+	for _, name := range shieldOnlyNames(s.ignoredShield, emittedShield) {
+		out = append(out, Entry{Repo: repo, Kind: kind, Name: name, Status: Ignored, Override: OverrideIgnored})
 	}
 	return out
+}
+
+func nameEntry(repo string, kind plan.Kind, name string, liveSet, managedOverride map[string]struct{}) Entry {
+	e := Entry{Repo: repo, Kind: kind, Name: name}
+	if _, ok := managedOverride[name]; ok {
+		e.Override = OverrideManaged
+	}
+	if _, ok := liveSet[name]; ok {
+		e.Status = Present
+	} else {
+		e.Status = Missing
+	}
+	return e
+}
+
+func extraNameEntry(repo string, kind plan.Kind, name string, ignored []string, shield, emitted map[string]struct{}) Entry {
+	e := Entry{Repo: repo, Kind: kind, Name: name, Status: Extra}
+	if !slices.Contains(ignored, name) {
+		return e
+	}
+	e.Status = Ignored
+	if _, shielded := shield[name]; shielded {
+		e.Override = OverrideIgnored
+		emitted[name] = struct{}{}
+	}
+	return e
 }
 
 // HasDrift reports whether any entry represents a state needing action.

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -24,6 +24,21 @@ const (
 	Ignored  Status = "ignored"  // on github and explicitly ignored
 )
 
+// Override records that an entry's effective layer differs from the
+// all-repos default — used by audit to surface layered drift.
+type Override string
+
+const (
+	// OverrideNone is the zero value: no cascade override applies.
+	OverrideNone Override = ""
+	// OverrideManaged indicates a per-repo.managed entry shadowed an
+	// all-repos.managed entry of the same name.
+	OverrideManaged Override = "managed"
+	// OverrideIgnored indicates a per-repo.ignored entry shielded an
+	// all-repos.managed entry of the same name.
+	OverrideIgnored Override = "ignored"
+)
+
 // Live captures observed state for a single repo.
 //
 // Vars is name → value because the GitHub API returns variable values.
@@ -42,6 +57,13 @@ type Entry struct {
 	Status       Status
 	DesiredValue string // populated for Mismatch on vars
 	LiveValue    string // populated for Mismatch on vars
+
+	// Override is non-empty when this entry resolved through a cross-layer
+	// override:
+	//   - OverrideManaged: per-repo.managed shadowed all-repos.managed.
+	//   - OverrideIgnored: per-repo.ignored shielded all-repos.managed.
+	// In both cases the implicit layer pair is per-repo over all-repos.
+	Override Override
 }
 
 // Compute produces diff entries for a single repo.
@@ -61,31 +83,46 @@ func Compute(repo string, intents []plan.Intent, desiredVars map[string]string, 
 
 func computeVars(repo string, intents []plan.Intent, desiredVars map[string]string, live Live, ignored config.Ignored) []Entry {
 	intended := map[string]struct{}{}
+	managedOverride := map[string]struct{}{}
+	ignoredShield := map[string]struct{}{}
 	out := make([]Entry, 0)
 	intentNames := make([]string, 0)
 	for _, in := range intents {
-		if in.Kind != plan.KindVar || in.Action != plan.ActionManaged {
+		if in.Kind != plan.KindVar {
 			continue
 		}
-		intended[in.Name] = struct{}{}
-		intentNames = append(intentNames, in.Name)
+		switch in.Action {
+		case plan.ActionManaged:
+			intended[in.Name] = struct{}{}
+			intentNames = append(intentNames, in.Name)
+			if in.OverridesAllRepos {
+				managedOverride[in.Name] = struct{}{}
+			}
+		case plan.ActionIgnored:
+			if in.ShieldsAllReposManaged {
+				ignoredShield[in.Name] = struct{}{}
+			}
+		}
 	}
 	sort.Strings(intentNames)
 
 	for _, name := range intentNames {
 		desired := desiredVars[name]
+		e := Entry{Repo: repo, Kind: plan.KindVar, Name: name}
+		if _, ok := managedOverride[name]; ok {
+			e.Override = OverrideManaged
+		}
 		if liveVal, ok := live.Vars[name]; ok {
-			status := Match
-			e := Entry{Repo: repo, Kind: plan.KindVar, Name: name, Status: status}
+			e.Status = Match
 			if liveVal != desired {
 				e.Status = Mismatch
 				e.DesiredValue = desired
 				e.LiveValue = liveVal
 			}
-			out = append(out, e)
 		} else {
-			out = append(out, Entry{Repo: repo, Kind: plan.KindVar, Name: name, Status: Missing})
+			e.Status = Missing
 		}
+		out = append(out, e)
 	}
 
 	liveNames := make([]string, 0, len(live.Vars))
@@ -93,29 +130,66 @@ func computeVars(repo string, intents []plan.Intent, desiredVars map[string]stri
 		liveNames = append(liveNames, n)
 	}
 	sort.Strings(liveNames)
+	emittedShield := map[string]struct{}{}
 	for _, name := range liveNames {
 		if _, ok := intended[name]; ok {
 			continue
 		}
-		status := Extra
+		e := Entry{Repo: repo, Kind: plan.KindVar, Name: name, Status: Extra}
 		if slices.Contains(ignored.Vars, name) {
-			status = Ignored
+			e.Status = Ignored
+			if _, shielded := ignoredShield[name]; shielded {
+				e.Override = OverrideIgnored
+				emittedShield[name] = struct{}{}
+			}
 		}
-		out = append(out, Entry{Repo: repo, Kind: plan.KindVar, Name: name, Status: status})
+		out = append(out, e)
+	}
+	// Emit shield-override rows for names that were not on the live target.
+	// The override is a configuration-level fact (per-repo.ignored shielded
+	// all-repos.managed) and is meaningful regardless of live presence.
+	shieldNames := make([]string, 0)
+	for name := range ignoredShield {
+		if _, ok := emittedShield[name]; ok {
+			continue
+		}
+		shieldNames = append(shieldNames, name)
+	}
+	sort.Strings(shieldNames)
+	for _, name := range shieldNames {
+		out = append(out, Entry{
+			Repo:     repo,
+			Kind:     plan.KindVar,
+			Name:     name,
+			Status:   Ignored,
+			Override: OverrideIgnored,
+		})
 	}
 	return out
 }
 
 func computeNames(repo string, kind plan.Kind, intents []plan.Intent, liveNames []string, ignored []string) []Entry {
 	intended := map[string]struct{}{}
+	managedOverride := map[string]struct{}{}
+	ignoredShield := map[string]struct{}{}
 	out := make([]Entry, 0)
 	intentNames := make([]string, 0)
 	for _, in := range intents {
-		if in.Kind != kind || in.Action != plan.ActionManaged {
+		if in.Kind != kind {
 			continue
 		}
-		intended[in.Name] = struct{}{}
-		intentNames = append(intentNames, in.Name)
+		switch in.Action {
+		case plan.ActionManaged:
+			intended[in.Name] = struct{}{}
+			intentNames = append(intentNames, in.Name)
+			if in.OverridesAllRepos {
+				managedOverride[in.Name] = struct{}{}
+			}
+		case plan.ActionIgnored:
+			if in.ShieldsAllReposManaged {
+				ignoredShield[in.Name] = struct{}{}
+			}
+		}
 	}
 	sort.Strings(intentNames)
 	liveSet := map[string]struct{}{}
@@ -124,23 +198,50 @@ func computeNames(repo string, kind plan.Kind, intents []plan.Intent, liveNames 
 	}
 
 	for _, name := range intentNames {
-		if _, ok := liveSet[name]; ok {
-			out = append(out, Entry{Repo: repo, Kind: kind, Name: name, Status: Present})
-		} else {
-			out = append(out, Entry{Repo: repo, Kind: kind, Name: name, Status: Missing})
+		e := Entry{Repo: repo, Kind: kind, Name: name}
+		if _, ok := managedOverride[name]; ok {
+			e.Override = OverrideManaged
 		}
+		if _, ok := liveSet[name]; ok {
+			e.Status = Present
+		} else {
+			e.Status = Missing
+		}
+		out = append(out, e)
 	}
 	sortedLive := append([]string(nil), liveNames...)
 	sort.Strings(sortedLive)
+	emittedShield := map[string]struct{}{}
 	for _, name := range sortedLive {
 		if _, ok := intended[name]; ok {
 			continue
 		}
-		status := Extra
+		e := Entry{Repo: repo, Kind: kind, Name: name, Status: Extra}
 		if slices.Contains(ignored, name) {
-			status = Ignored
+			e.Status = Ignored
+			if _, shielded := ignoredShield[name]; shielded {
+				e.Override = OverrideIgnored
+				emittedShield[name] = struct{}{}
+			}
 		}
-		out = append(out, Entry{Repo: repo, Kind: kind, Name: name, Status: status})
+		out = append(out, e)
+	}
+	shieldNames := make([]string, 0)
+	for name := range ignoredShield {
+		if _, ok := emittedShield[name]; ok {
+			continue
+		}
+		shieldNames = append(shieldNames, name)
+	}
+	sort.Strings(shieldNames)
+	for _, name := range shieldNames {
+		out = append(out, Entry{
+			Repo:     repo,
+			Kind:     kind,
+			Name:     name,
+			Status:   Ignored,
+			Override: OverrideIgnored,
+		})
 	}
 	return out
 }

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -120,6 +120,116 @@ func TestCompute_IgnoredSuppressesExtra(t *testing.T) {
 	checkEntries(t, got, want)
 }
 
+func TestCompute_OverrideManaged_AttachesToManagedEntries(t *testing.T) {
+	t.Parallel()
+	// A per-repo.managed entry that shadowed an all-repos.managed entry
+	// produces an Intent with OverridesAllRepos=true. Compute must surface
+	// that on the resulting diff Entry as Override=OverrideManaged so audit
+	// can render an override row, regardless of match/mismatch/missing/present.
+	intents := []plan.Intent{
+		{Repo: "acme", Kind: plan.KindVar, Name: "MATCH_OVR", Action: plan.ActionManaged, OverridesAllRepos: true},
+		{Repo: "acme", Kind: plan.KindVar, Name: "MISS_OVR", Action: plan.ActionManaged, OverridesAllRepos: true},
+		{Repo: "acme", Kind: plan.KindSecret, Name: "SEC_OVR", Action: plan.ActionManaged, OverridesAllRepos: true},
+		{Repo: "acme", Kind: plan.KindDependabot, Name: "DEP_OVR", Action: plan.ActionManaged, OverridesAllRepos: true},
+		{Repo: "acme", Kind: plan.KindVar, Name: "PLAIN", Action: plan.ActionManaged},
+	}
+	desired := map[string]string{
+		"MATCH_OVR": "v",
+		"MISS_OVR":  "v",
+		"PLAIN":     "p",
+	}
+	live := Live{
+		Vars:       map[string]string{"MATCH_OVR": "v", "PLAIN": "p"},
+		Secrets:    []string{"SEC_OVR"},
+		Dependabot: []string{},
+	}
+	got := Compute("acme", intents, desired, live, config.Ignored{})
+	overrideOf := map[string]Override{}
+	statusOf := map[string]Status{}
+	for _, e := range got {
+		key := string(e.Kind) + "/" + e.Name
+		overrideOf[key] = e.Override
+		statusOf[key] = e.Status
+	}
+	wantOverride := map[string]Override{
+		"vars/MATCH_OVR":       OverrideManaged,
+		"vars/MISS_OVR":        OverrideManaged,
+		"secrets/SEC_OVR":      OverrideManaged,
+		"dependabot/DEP_OVR":   OverrideManaged,
+		"vars/PLAIN":           OverrideNone,
+	}
+	for k, want := range wantOverride {
+		if overrideOf[k] != want {
+			t.Errorf("%s override: got %q want %q", k, overrideOf[k], want)
+		}
+	}
+	if statusOf["vars/MATCH_OVR"] != Match {
+		t.Errorf("MATCH_OVR status: got %q want match", statusOf["vars/MATCH_OVR"])
+	}
+	if statusOf["vars/MISS_OVR"] != Missing {
+		t.Errorf("MISS_OVR status: got %q want missing", statusOf["vars/MISS_OVR"])
+	}
+	if statusOf["secrets/SEC_OVR"] != Present {
+		t.Errorf("SEC_OVR status: got %q want present", statusOf["secrets/SEC_OVR"])
+	}
+	if statusOf["dependabot/DEP_OVR"] != Missing {
+		t.Errorf("DEP_OVR status: got %q want missing", statusOf["dependabot/DEP_OVR"])
+	}
+}
+
+func TestCompute_OverrideIgnored_ShieldsAllReposManaged(t *testing.T) {
+	t.Parallel()
+	// An ActionIgnored intent with ShieldsAllReposManaged=true is the
+	// per-repo.ignored shadowing all-repos.managed case. The resulting
+	// diff Entry must be Status=Ignored, Override=OverrideIgnored.
+	// Behavior must hold both when the name is present on github (case A
+	// here uses live=present) and when it's absent (case B below uses
+	// live=absent — the row must still be emitted as a config-level fact).
+	intents := []plan.Intent{
+		{Repo: "acme", Kind: plan.KindVar, Name: "PRESENT_SHIELD", Action: plan.ActionIgnored, ShieldsAllReposManaged: true},
+		{Repo: "acme", Kind: plan.KindVar, Name: "ABSENT_SHIELD", Action: plan.ActionIgnored, ShieldsAllReposManaged: true},
+		{Repo: "acme", Kind: plan.KindSecret, Name: "SEC_SHIELD", Action: plan.ActionIgnored, ShieldsAllReposManaged: true},
+		{Repo: "acme", Kind: plan.KindDependabot, Name: "DEP_SHIELD", Action: plan.ActionIgnored, ShieldsAllReposManaged: true},
+		{Repo: "acme", Kind: plan.KindVar, Name: "PLAIN_IG", Action: plan.ActionIgnored},
+	}
+	live := Live{
+		Vars:    map[string]string{"PRESENT_SHIELD": "v", "PLAIN_IG": "p"},
+		Secrets: []string{"SEC_SHIELD"},
+	}
+	ig := config.Ignored{
+		Vars:       []string{"PRESENT_SHIELD", "ABSENT_SHIELD", "PLAIN_IG"},
+		Secrets:    []string{"SEC_SHIELD"},
+		Dependabot: []string{"DEP_SHIELD"},
+	}
+	got := Compute("acme", intents, nil, live, ig)
+	overrideOf := map[string]Override{}
+	statusOf := map[string]Status{}
+	for _, e := range got {
+		key := string(e.Kind) + "/" + e.Name
+		overrideOf[key] = e.Override
+		statusOf[key] = e.Status
+	}
+	for _, k := range []string{
+		"vars/PRESENT_SHIELD",
+		"vars/ABSENT_SHIELD",
+		"secrets/SEC_SHIELD",
+		"dependabot/DEP_SHIELD",
+	} {
+		if statusOf[k] != Ignored {
+			t.Errorf("%s status: got %q want ignored", k, statusOf[k])
+		}
+		if overrideOf[k] != OverrideIgnored {
+			t.Errorf("%s override: got %q want %q", k, overrideOf[k], OverrideIgnored)
+		}
+	}
+	if overrideOf["vars/PLAIN_IG"] != OverrideNone {
+		t.Errorf("PLAIN_IG override: got %q want none", overrideOf["vars/PLAIN_IG"])
+	}
+	if HasDrift(got) {
+		t.Errorf("ignored entries (including overrides) must not register as drift")
+	}
+}
+
 func TestHasDrift(t *testing.T) {
 	t.Parallel()
 	cases := []struct {

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -46,6 +46,12 @@ type Intent struct {
 	// audit-side override reporting; runtime behavior is unaffected.
 	OverridesAllRepos bool
 
+	// ShieldsAllReposManaged is true when this is an ActionIgnored intent
+	// produced by per-repo.ignored shielding an all-repos.managed entry.
+	// Reserved for audit-side override reporting; runtime behavior is
+	// unaffected.
+	ShieldsAllReposManaged bool
+
 	// IsOrg distinguishes an org-level intent (different GitHub object class)
 	// from a repo-level intent. When true, Repo is empty and the entry is
 	// targeted at the named organization.
@@ -122,9 +128,10 @@ func ForRepoCascade(repoName string, allRepos, perRepo *config.Repo) []Intent {
 }
 
 type cascadeWinner struct {
-	action            Action
-	entry             *config.Entry
-	overridesAllRepos bool
+	action                 Action
+	entry                  *config.Entry
+	overridesAllRepos      bool
+	shieldsAllReposManaged bool
 }
 
 func appendCascadeKind(out []Intent, repo string, kind Kind, allRepos, perRepo *config.Repo) []Intent {
@@ -151,9 +158,11 @@ func appendCascadeKind(out []Intent, repo string, kind Kind, allRepos, perRepo *
 		})
 	}
 	for _, n := range ignoredNames {
+		w := resolved[n]
 		out = append(out, Intent{
 			Repo: repo, Kind: kind, Name: n,
-			Action: ActionIgnored,
+			Action:                 ActionIgnored,
+			ShieldsAllReposManaged: w.shieldsAllReposManaged,
 		})
 	}
 	return out
@@ -176,7 +185,11 @@ func resolveCascade(allRepos, perRepo *config.Repo, kind Kind) map[string]cascad
 		if _, ok := resolved[n]; ok {
 			continue
 		}
-		resolved[n] = cascadeWinner{action: ActionIgnored}
+		w := cascadeWinner{action: ActionIgnored}
+		if _, hits := arMan[n]; hits {
+			w.shieldsAllReposManaged = true
+		}
+		resolved[n] = w
 	}
 	for n, e := range arMan {
 		if _, ok := resolved[n]; ok {

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -72,9 +72,10 @@ func TestForRepoCascade_Matrix(t *testing.T) {
 	t.Parallel()
 
 	type want struct {
-		action            Action
-		fromAllRepos      bool // true → entry should equal all-repos's entry
-		overridesAllRepos bool
+		action                 Action
+		fromAllRepos           bool // true → entry should equal all-repos's entry
+		overridesAllRepos      bool
+		shieldsAllReposManaged bool
 	}
 
 	tests := []struct {
@@ -114,10 +115,12 @@ func TestForRepoCascade_Matrix(t *testing.T) {
 			},
 		},
 		{
-			name:      "per-repo.ignored shields all-repos.managed",
-			allMan:    []string{"X"},
-			repoIg:    []string{"X"},
-			wantNames: map[string]want{"X": {action: ActionIgnored}},
+			name:   "per-repo.ignored shields all-repos.managed",
+			allMan: []string{"X"},
+			repoIg: []string{"X"},
+			wantNames: map[string]want{
+				"X": {action: ActionIgnored, shieldsAllReposManaged: true},
+			},
 		},
 		{
 			name:      "per-repo.managed overrides all-repos.ignored",
@@ -175,6 +178,10 @@ func TestForRepoCascade_Matrix(t *testing.T) {
 				if got.OverridesAllRepos != w.overridesAllRepos {
 					t.Errorf("%s overrides: got %v want %v",
 						name, got.OverridesAllRepos, w.overridesAllRepos)
+				}
+				if got.ShieldsAllReposManaged != w.shieldsAllReposManaged {
+					t.Errorf("%s shields: got %v want %v",
+						name, got.ShieldsAllReposManaged, w.shieldsAllReposManaged)
 				}
 				if w.action == ActionManaged {
 					if got.Entry == nil {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -129,13 +129,37 @@ func writeStanza(out io.Writer, org, repo string, entries []diff.Entry, showIgno
 		if e.Status == diff.Ignored && !showIgnored {
 			continue
 		}
-		switch e.Status {
-		case diff.Mismatch:
-			fmt.Fprintf(out, "  %s/%s: mismatch (yaml=%q live=%q)\n", e.Kind, e.Name, e.DesiredValue, e.LiveValue)
-		default:
-			fmt.Fprintf(out, "  %s/%s: %s\n", e.Kind, e.Name, e.Status)
-		}
+		writeEntryLine(out, e)
 	}
+}
+
+// writeEntryLine renders a single diff Entry. Cross-layer overrides are
+// surfaced inline so audit output makes layered drift visible:
+//
+//   - Override=OverrideManaged: append " override(per-repo>all-repos)"
+//     to the regular status line. Example:
+//     "  vars/X: match override(per-repo>all-repos)"
+//     "  vars/X: mismatch (yaml="a" live="b") override(per-repo>all-repos)"
+//
+//   - Override=OverrideIgnored: replace the bare "ignored" status with
+//     "override (ignored) (per-repo>all-repos.managed)". The caller is
+//     responsible for honoring --show-ignored.
+func writeEntryLine(out io.Writer, e diff.Entry) {
+	switch {
+	case e.Status == diff.Ignored && e.Override == diff.OverrideIgnored:
+		fmt.Fprintf(out, "  %s/%s: override (ignored) (per-repo>all-repos.managed)\n", e.Kind, e.Name)
+	case e.Status == diff.Mismatch:
+		fmt.Fprintf(out, "  %s/%s: mismatch (yaml=%q live=%q)%s\n", e.Kind, e.Name, e.DesiredValue, e.LiveValue, overrideSuffix(e))
+	default:
+		fmt.Fprintf(out, "  %s/%s: %s%s\n", e.Kind, e.Name, e.Status, overrideSuffix(e))
+	}
+}
+
+func overrideSuffix(e diff.Entry) string {
+	if e.Override == diff.OverrideManaged {
+		return " override(per-repo>all-repos)"
+	}
+	return ""
 }
 
 // ApplyRepo writes managed values for a single repo. It never deletes and

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -1856,6 +1856,111 @@ github.com:
 	}
 }
 
+// TestAuditRepo_ManagedOverrideRow asserts that when a per-repo.managed
+// entry shadows an all-repos.managed entry, audit emits an override row
+// for that repo identifying both layers, regardless of the underlying
+// match/mismatch/missing status.
+func TestAuditRepo_ManagedOverrideRow(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "secrets.yml")
+	if err := writeFile(cfgPath, []byte(`
+github.com:
+  example:
+    all-repos:
+      managed:
+        vars:
+          V_MATCH:
+            value: shared
+          V_MISS:
+            value: shared
+    per-repo:
+      acme:
+        managed:
+          vars:
+            V_MATCH:
+              value: acme-match
+            V_MISS:
+              value: acme-miss
+`)); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	be := &fakeBackend{vars: map[string]string{"V_MATCH": "acme-match"}}
+	var out bytes.Buffer
+	if _, err := AuditRepo(context.Background(), cfg, "example", "acme", be, &out, false); err != nil {
+		t.Fatal(err)
+	}
+	s := out.String()
+	for _, want := range []string{
+		"V_MATCH: match override(per-repo>all-repos)",
+		"V_MISS: missing",
+		"override(per-repo>all-repos)",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("expected override marker %q in output:\n%s", want, s)
+		}
+	}
+}
+
+// TestAuditRepo_IgnoredOverrideRow asserts that when a per-repo.ignored
+// entry shields an all-repos.managed entry, audit emits an
+// "override (ignored)" row when --show-ignored is set, and is silent
+// about the override otherwise.
+func TestAuditRepo_IgnoredOverrideRow(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "secrets.yml")
+	if err := writeFile(cfgPath, []byte(`
+github.com:
+  example:
+    all-repos:
+      managed:
+        vars:
+          V_SHIELD:
+            value: shared
+    per-repo:
+      acme:
+        ignored:
+          vars:
+            - V_SHIELD
+`)); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Without --show-ignored: silent about V_SHIELD even though it shielded
+	// an all-repos.managed entry.
+	be := &fakeBackend{}
+	var quiet bytes.Buffer
+	if _, err := AuditRepo(context.Background(), cfg, "example", "acme", be, &quiet, false); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(quiet.String(), "V_SHIELD") {
+		t.Errorf("ignored override should be silent without --show-ignored; got:\n%s", quiet.String())
+	}
+
+	// With --show-ignored: an "override (ignored)" row that names both layers.
+	var loud bytes.Buffer
+	if _, err := AuditRepo(context.Background(), cfg, "example", "acme", be, &loud, true); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"V_SHIELD: override (ignored)",
+		"per-repo>all-repos.managed",
+	} {
+		if !strings.Contains(loud.String(), want) {
+			t.Errorf("expected %q in --show-ignored output:\n%s", want, loud.String())
+		}
+	}
+}
+
 // gatedBackend extends fakeBackend with a per-call gate. Every call to
 // ListRepoVariables increments inFlight (then decrements on return) and
 // observes maxInFlight, letting tests assert that no more than the


### PR DESCRIPTION
Fixes #11

Adds cross-layer override visibility to `audit` output so layered drift
between `all-repos` and `per-repo` no longer hides.

- `plan.Intent` gains `ShieldsAllReposManaged`, set when a
  `per-repo.ignored` entry shadowed an `all-repos.managed` entry of the
  same name (the mirror of the existing `OverridesAllRepos` flag).
- `diff.Entry` gains an `Override` field
  (`OverrideNone`/`OverrideManaged`/`OverrideIgnored`) populated by
  `Compute` from the new intent metadata. Shield rows are emitted even
  when the live target carries no value, since the override is a
  configuration-level fact.
- `runner.writeStanza` decorates audit lines accordingly:
  - `OverrideManaged` appends `override(per-repo>all-repos)` to the
    normal status (match/mismatch/missing/present).
  - `OverrideIgnored` prints
    `override (ignored) (per-repo>all-repos.managed)` and is gated by
    `--show-ignored` (silent without it).

Tests cover the cascade flag in `plan`, the override propagation in
`diff`, and the rendered audit output (with and without
`--show-ignored`) in `runner`. All packages remain at >=80% coverage;
`golangci-lint` is clean.