### PR TITLE
release: goreleaser config, version subcommand, README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
   ci:
     uses: xmidt-org/shared-go/.github/workflows/ci.yml@c1c3acacf1c0a4ee7852b0d41c1174f52fa412e9 # v4.9.33
     with:
-      release-type:   program
-      yaml-lint-skip: true
+      release-type:        program
+      release-custom-file: true
+      yaml-lint-skip:      true
     secrets: inherit

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: 2026 Weston Schmidt <weston_schmidt@alumni.purdue.edu>
+# SPDX-License-Identifier: Apache-2.0
+---
+version: 2
+project_name: ghsecretman
+
+builds:
+  - id: ghsecretman
+    main: ./cmd/ghsecretman
+    binary: ghsecretman
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    ldflags:
+      - -s -w
+      - -X main.version={{ .Version }}
+      - -X main.commit={{ .FullCommit }}
+      - -X main.date={{ .CommitDate }}
+
+archives:
+  - formats: [tar.gz]
+    wrap_in_directory: true
+    name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    files:
+      - LICENSE
+      - LICENSES/**/*
+      - README.md
+
+checksum:
+  name_template: "{{ .ProjectName }}-{{ .Version }}-checksums.txt"
+  algorithm: sha512
+
+changelog:
+  use: github
+  sort: asc
+  filters:
+    exclude:
+      - "^test:"
+      - "^chore"
+      - "merge conflict"
+      - Merge pull request
+      - Merge remote-tracking branch
+      - Merge branch
+      - go mod tidy
+  groups:
+    - title: "Dependency Updates"
+      regexp: '^.*?(feat|fix)\(deps\)!?:.+$'
+      order: 300
+    - title: "New Features"
+      regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
+      order: 100
+    - title: "Bug Fixes"
+      regexp: '^.*?fix(\([[:word:]]+\))??!?:.+$'
+      order: 200
+    - title: "Documentation Updates"
+      regexp: '^.*?doc(\([[:word:]]+\))??!?:.+$'
+      order: 400
+    - title: Other Work
+      order: 9999
+
+release:
+  draft: false
+  prerelease: auto

--- a/README.md
+++ b/README.md
@@ -4,6 +4,58 @@ A tool for managing GitHub Actions secrets, Actions variables, and Dependabot se
 
 See the design and full requirements in [PRD #1](https://github.com/schmidtw/ghsecretman/issues/1).
 
+## Install
+
+Pre-built binaries for darwin and linux on amd64 and arm64 are attached to each release on the [Releases page](https://github.com/schmidtw/ghsecretman/releases). Each release also publishes a `*-checksums.txt` file with SHA-512 sums of every artifact.
+
+```sh
+# Pick the asset that matches your platform, then:
+tar xzf ghsecretman-<version>-<os>-<arch>.tar.gz
+sudo install ghsecretman-<version>-<os>-<arch>/ghsecretman /usr/local/bin/
+```
+
+To build from source:
+
+```sh
+go install github.com/schmidtw/ghsecretman/cmd/ghsecretman@latest
+```
+
+`ghsecretman version` prints the version, commit, and build date stamped in at release time.
+
+## Quick Start
+
+`ghsecretman` authenticates with a personal access token from `GITHUB_TOKEN` (preferred) or `GH_TOKEN`. The token needs the scopes required to read and write the secrets/variables you list in the YAML.
+
+A minimal config (`secrets.yml`) for an `audit` against one repo:
+
+```yaml
+github.com:
+  example-org:
+    per-repo:
+      example-repo:
+        managed:
+          vars:
+            APP_ENV:
+              value: production
+```
+
+Run a read-only audit:
+
+```sh
+export GITHUB_TOKEN=ghp_...
+ghsecretman audit --config secrets.yml --org example-org --repo example-repo
+```
+
+`audit` exits non-zero if any drift is found, so it is safe to run from CI as a drift detector. To write managed values, use `apply`; to also delete unlisted values, use `enforce` (which requires `--yes` for the destructive path or supports `--dry-run` for review).
+
+Omit `--repo` to iterate every repo in the org concurrently; `--concurrency` bounds the worker pool.
+
+## Configuration
+
+The full YAML schema (`org`, `per-repo`, `all-repos`, `managed`, `ignored`, value sources, precedence rules, `org`-level `scope`/`repos`) is documented in [PRD #1](https://github.com/schmidtw/ghsecretman/issues/1). A complete annotated example lives in [`example.yml`](example.yml).
+
+Top-level keys other than `github.com:` are ignored, so the same file can carry sections owned by other tools.
+
 ## License
 
 Apache-2.0. See [LICENSE](LICENSE).

--- a/cmd/ghsecretman/main.go
+++ b/cmd/ghsecretman/main.go
@@ -19,8 +19,13 @@ import (
 	"github.com/schmidtw/ghsecretman/internal/runner"
 )
 
-// version is set at build time via -ldflags "-X main.version=<value>".
-var version = "dev"
+// version, commit, and date are set at build time via -ldflags
+// "-X main.version=<value> -X main.commit=<sha> -X main.date=<rfc3339>".
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
 
 // backendFactory is overridden in tests to inject a fake backend.
 var backendFactory = func() (gh.Backend, error) { return gh.NewClientFromEnv() }
@@ -51,6 +56,9 @@ func run(args []string, ver string, stdout, stderr io.Writer) int {
 			return runApply(args[2:], stdout, stderr)
 		case "enforce":
 			return runEnforce(args[2:], stdout, stderr)
+		case "version":
+			fmt.Fprintf(stdout, "ghsecretman %s\ncommit %s\nbuilt %s\n", ver, commit, date)
+			return 0
 		}
 	}
 

--- a/cmd/ghsecretman/main_test.go
+++ b/cmd/ghsecretman/main_test.go
@@ -15,6 +15,40 @@ import (
 	gh "github.com/schmidtw/ghsecretman/internal/github"
 )
 
+func swapBuildVars(t *testing.T, c, d string) {
+	t.Helper()
+	prevC, prevD := commit, date
+	commit, date = c, d
+	t.Cleanup(func() { commit, date = prevC, prevD })
+}
+
+func TestRun_VersionSubcommand(t *testing.T) {
+	swapBuildVars(t, "abcdef1", "2026-04-26T00:00:00Z")
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"ghsecretman", "version"}, "1.2.3", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit: got %d want 0; stderr=%q", code, stderr.String())
+	}
+	want := "ghsecretman 1.2.3\ncommit abcdef1\nbuilt 2026-04-26T00:00:00Z\n"
+	if got := stdout.String(); got != want {
+		t.Fatalf("stdout: got %q, want %q", got, want)
+	}
+}
+
+func TestRun_VersionSubcommand_Defaults(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"ghsecretman", "version"}, "dev", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit: got %d want 0; stderr=%q", code, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{"ghsecretman dev", "commit ", "built "} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout missing %q: %q", want, out)
+		}
+	}
+}
+
 func TestRun_Version(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
Fixes #13

Adds release packaging:

- `.goreleaser.yaml` builds darwin and linux for amd64 and arm64, archives as `tar.gz`, SHA-512 checksums, ldflags-injected `main.version` / `main.commit` / `main.date`.
- `ghsecretman version` subcommand prints the three values.
- CI switched to `release-custom-file: true` so the shared-go workflow uses the in-repo goreleaser config on tag push (`v*`).
- README updated with Install, Quick Start, Configuration, and License sections.

The first tag (`v0.1.0`) needs to be cut after this PR merges to verify the publish path end-to-end; the auto-releaser workflow handles that on its daily schedule.