### PR TITLE
cli: add example subcommand and richer top-level help

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Omit `--repo` to iterate every repo in the org concurrently; `--concurrency` bou
 
 ## Configuration
 
-The full YAML schema (`org`, `per-repo`, `all-repos`, `managed`, `ignored`, value sources, precedence rules, `org`-level `scope`/`repos`) is documented in [PRD #1](https://github.com/schmidtw/ghsecretman/issues/1). A complete annotated example lives in [`example.yml`](example.yml).
+The full YAML schema (`org`, `per-repo`, `all-repos`, `managed`, `ignored`, value sources, precedence rules, `org`-level `scope`/`repos`) is documented in [PRD #1](https://github.com/schmidtw/ghsecretman/issues/1). A complete annotated example lives in [`internal/schema/example.yml`](internal/schema/example.yml), and the same content is embedded in the binary — run `ghsecretman example` to print it, or `ghsecretman example -o secrets.yml` to write a starter config.
 
 Top-level keys other than `github.com:` are ignored, so the same file can carry sections owned by other tools.
 

--- a/cmd/ghsecretman/main.go
+++ b/cmd/ghsecretman/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/schmidtw/ghsecretman/internal/config"
 	gh "github.com/schmidtw/ghsecretman/internal/github"
 	"github.com/schmidtw/ghsecretman/internal/runner"
+	"github.com/schmidtw/ghsecretman/internal/schema"
 )
 
 // version, commit, and date are set at build time via -ldflags
@@ -56,8 +57,13 @@ func run(args []string, ver string, stdout, stderr io.Writer) int {
 			return runApply(args[2:], stdout, stderr)
 		case "enforce":
 			return runEnforce(args[2:], stdout, stderr)
+		case "example":
+			return runExample(args[2:], stdout, stderr)
 		case "version":
 			fmt.Fprintf(stdout, "ghsecretman %s\ncommit %s\nbuilt %s\n", ver, commit, date)
+			return 0
+		case "-h", "--help", "help":
+			printUsage(stdout)
 			return 0
 		}
 	}
@@ -73,8 +79,69 @@ func run(args []string, ver string, stdout, stderr io.Writer) int {
 		return 0
 	}
 
-	fmt.Fprintln(stderr, "usage: ghsecretman <audit|apply|enforce> --config <path> --org <name> --repo <name>")
+	printUsage(stderr)
 	return 2
+}
+
+// printUsage writes the top-level help text. It is shown for `-h`, `--help`,
+// `help`, and bare invocations.
+func printUsage(w io.Writer) {
+	fmt.Fprint(w, `ghsecretman: manage GitHub Actions secrets, Actions variables, and
+             Dependabot secrets across an organization from a YAML file.
+
+usage:
+  ghsecretman <command> [flags]
+
+commands:
+  audit    Read-only diff between YAML config and live state.
+  apply    Write managed values; never delete.
+  enforce  Apply, then delete unlisted values. Supports --dry-run.
+  example  Print an annotated example YAML config (or write it with -o).
+  version  Print version, commit, and build date.
+
+authentication:
+  Reads GITHUB_TOKEN (preferred) or GH_TOKEN from the environment.
+
+Run 'ghsecretman <command> -h' for command-specific flags.
+See 'ghsecretman example' for the full schema with annotations.
+`)
+}
+
+// runExample prints the embedded annotated example YAML configuration to
+// stdout, or writes it to a file when -o/--output is supplied. Existing files
+// are not overwritten unless -f/--force is set.
+func runExample(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("example", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var output string
+	fs.StringVar(&output, "output", "", "write to file instead of stdout")
+	fs.StringVar(&output, "o", "", "write to file instead of stdout (shorthand)")
+	var force bool
+	fs.BoolVar(&force, "force", false, "overwrite an existing output file")
+	fs.BoolVar(&force, "f", false, "overwrite (shorthand)")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	if output == "" {
+		if _, err := io.WriteString(stdout, schema.Example); err != nil {
+			fmt.Fprintf(stderr, "example: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+
+	if !force {
+		if _, err := os.Stat(output); err == nil {
+			fmt.Fprintf(stderr, "example: %s already exists; pass --force to overwrite\n", output)
+			return 2
+		}
+	}
+	if err := os.WriteFile(output, []byte(schema.Example), 0o600); err != nil {
+		fmt.Fprintf(stderr, "example: %v\n", err)
+		return 1
+	}
+	return 0
 }
 
 func runEnforce(args []string, stdout, stderr io.Writer) int {

--- a/cmd/ghsecretman/main_test.go
+++ b/cmd/ghsecretman/main_test.go
@@ -909,3 +909,105 @@ github.com:
 		t.Errorf("expected one repo var set; got %v", be.setVars)
 	}
 }
+
+func TestRun_Help_PrintsCommandList(t *testing.T) {
+	for _, arg := range []string{"-h", "--help", "help"} {
+		t.Run(arg, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := run([]string{"ghsecretman", arg}, "dev", &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("exit: got %d want 0; stderr=%q", code, stderr.String())
+			}
+			out := stdout.String()
+			if !strings.Contains(out, "commands:") {
+				t.Fatalf("stdout missing commands section: %q", out)
+			}
+			for _, sub := range []string{"audit", "apply", "enforce", "example", "version"} {
+				if !strings.Contains(out, sub) {
+					t.Errorf("stdout missing subcommand %q", sub)
+				}
+			}
+		})
+	}
+}
+
+func TestRun_Example_Stdout(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"ghsecretman", "example"}, "dev", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit: got %d want 0; stderr=%q", code, stderr.String())
+	}
+	for _, marker := range []string{"github.com:", "managed:", "ignored:", "per-repo:", "all-repos:"} {
+		if !strings.Contains(stdout.String(), marker) {
+			t.Errorf("stdout missing schema marker %q", marker)
+		}
+	}
+}
+
+func TestRun_Example_OutputFile(t *testing.T) {
+	for _, flag := range []string{"-o", "--output"} {
+		t.Run(flag, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.yml")
+			var stdout, stderr bytes.Buffer
+			code := run([]string{"ghsecretman", "example", flag, path}, "dev", &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("exit: got %d want 0; stderr=%q", code, stderr.String())
+			}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(data), "github.com:") {
+				t.Fatalf("file missing expected content: %q", data)
+			}
+			if stdout.Len() != 0 {
+				t.Errorf("stdout should be empty when writing to file: %q", stdout.String())
+			}
+		})
+	}
+}
+
+func TestRun_Example_RefuseOverwrite(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yml")
+	if err := os.WriteFile(path, []byte("existing"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"ghsecretman", "example", "-o", path}, "dev", &stdout, &stderr)
+	if code == 0 {
+		t.Fatal("expected non-zero exit when refusing to overwrite")
+	}
+	if !strings.Contains(stderr.String(), "exists") {
+		t.Errorf("stderr should explain the refusal: %q", stderr.String())
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "existing" {
+		t.Fatalf("file should not have been modified: %q", data)
+	}
+}
+
+func TestRun_Example_ForceOverwrite(t *testing.T) {
+	for _, flag := range []string{"-f", "--force"} {
+		t.Run(flag, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.yml")
+			if err := os.WriteFile(path, []byte("existing"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			var stdout, stderr bytes.Buffer
+			code := run([]string{"ghsecretman", "example", "-o", path, flag}, "dev", &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("exit: got %d want 0; stderr=%q", code, stderr.String())
+			}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(data), "github.com:") {
+				t.Fatalf("file not overwritten with example: %q", data)
+			}
+		})
+	}
+}

--- a/internal/schema/example.yml
+++ b/internal/schema/example.yml
@@ -27,11 +27,11 @@ github.com:
       # These secrets are not managed by this location and will never be altered.
       ignored:
         vars:
-          - GOO
+          - EXAMPLE_VAR
         secrets:
-          - GOO
+          - EXAMPLE_SECRET
         dependabot:
-          - GOO
+          - EXAMPLE_DEPENDABOT_SECRET
     # variables and secrets to set/audit on a per repo basis.  These will
     # often be unique per repo.
     per-repo:
@@ -51,12 +51,9 @@ github.com:
               env: ENV_VAR_NAME
         # These secrets are not managed by this location and will never be altered.
         ignored:
-          vars:
-            - GOO
-          secrets:
-            - GOO
-          dependabot:
-            - GOO
+          vars: []
+          secrets: []
+          dependabot: []
     # variables and secrets to set/audit for all repos.  This generally will
     # be replace by org level secrets, but this is still valuable to control.
     all-repos:
@@ -71,17 +68,17 @@ github.com:
         vars:
           RPM_GPG_PUBLIC_KEY:
             value:
-            file: ../RPM-GPG-KEY-example
+            file: ./example.file
         secrets:
           PUSH_TAG_TOKEN:
-            value: ghp_secret
+            value: ghp_secret...
             env: ENV_VAR_NAME
-            file: ./RPM-GPG-KEY-example.private
+            file: ./example.secret.file
         dependabot:
           REPO_FETCHING_TOKEN:
-            value: ghp_secret
+            value: ghp_secret...
             env: ENV_VAR_NAME
-            file: ./RPM-GPG-KEY-example.private
+            file: ./example.private.file
       # When something is marked as ignored, it will be ignored for all repos,
       # this allows a simple way to do this without needing to have a per repo
       # entry everywhere.

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2026 Weston Schmidt <weston_schmidt@alumni.purdue.edu>
+// SPDX-License-Identifier: Apache-2.0
+
+// Package schema exposes the canonical annotated example YAML configuration
+// for ghsecretman. The example is embedded at build time so the binary
+// always carries the schema documentation matching its own behavior.
+package schema
+
+import _ "embed"
+
+//go:embed example.yml
+var Example string

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2026 Weston Schmidt <weston_schmidt@alumni.purdue.edu>
+// SPDX-License-Identifier: Apache-2.0
+
+package schema
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExample_NotEmpty(t *testing.T) {
+	t.Parallel()
+	if Example == "" {
+		t.Fatal("Example is empty; embed failed")
+	}
+}
+
+func TestExample_HasSchemaMarkers(t *testing.T) {
+	t.Parallel()
+	for _, marker := range []string{
+		"github.com:",
+		"managed:",
+		"ignored:",
+		"per-repo:",
+		"all-repos:",
+	} {
+		if !strings.Contains(Example, marker) {
+			t.Errorf("Example missing schema marker %q", marker)
+		}
+	}
+}


### PR DESCRIPTION
Adds a self-documenting `example` subcommand and replaces the near-empty default help with a multi-command usage block.

- `ghsecretman example` prints the annotated YAML to stdout.
- `ghsecretman example -o secrets.yml` writes a starter file (refuses to overwrite without `-f`/`--force`).
- `-h`, `--help`, `help`, and bare invocations now list every subcommand with a one-line description and point at `ghsecretman example` for the schema.

Canonical `example.yml` moved to `internal/schema/example.yml` so the cmd package can embed it (`go:embed` cannot reference paths outside the package directory). README updated.