### PR TITLE
docs: explain that repo iteration requires an all-repos or per-repo block

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ The full YAML schema (`org`, `per-repo`, `all-repos`, `managed`, `ignored`, valu
 
 Top-level keys other than `github.com:` are ignored, so the same file can carry sections owned by other tools.
 
+**Repo iteration is opt-in.** ghsecretman only enumerates an org's repositories when the YAML has either an `all-repos:` block or a `per-repo:` block for that repo. Without either, repo-level secrets/variables are invisible to the tool. If you only intend to manage org-level objects but also want existing repo-level cruft cleaned up, include an empty `all-repos:` block (empty `managed` maps and empty `ignored` lists). With nothing under `managed`, every existing repo-level entry is reported as `extra` by `audit` and deleted by `enforce`. Run `ghsecretman enforce --dry-run` first to confirm the list before letting deletes fire.
+
 ## License
 
 Apache-2.0. See [LICENSE](LICENSE).

--- a/internal/schema/example.yml
+++ b/internal/schema/example.yml
@@ -56,6 +56,30 @@ github.com:
           dependabot: []
     # variables and secrets to set/audit for all repos.  This generally will
     # be replace by org level secrets, but this is still valuable to control.
+    #
+    # IMPORTANT — repo iteration is opt-in:
+    # ghsecretman only enumerates the org's repositories when the YAML has
+    # either an `all-repos:` block or a `per-repo:` block for that repo.
+    # Without either, audit/apply/enforce do not look at any repo, and
+    # existing repo-level secrets/variables are invisible to the tool.
+    #
+    # If you only intend to manage org-level objects but also want
+    # repo-level cruft cleaned up, include an empty `all-repos:` block:
+    #
+    #     all-repos:
+    #       managed:
+    #         vars: {}
+    #         secrets: {}
+    #         dependabot: {}
+    #       ignored:
+    #         vars: []
+    #         secrets: []
+    #         dependabot: []
+    #
+    # With nothing under `managed`, every existing repo-level entry is
+    # reported as `extra` by audit and DELETED by enforce. Run
+    # `ghsecretman enforce --dry-run` first to confirm the list before
+    # letting deletes fire.
     all-repos:
       # These secrets are managed by this location & will always be made to
       # match this value.


### PR DESCRIPTION
A YAML with only an `org:` block silently skips every repo, so existing repo-level secrets/variables are invisible to audit/apply/enforce. Document the trigger condition and the empty-`all-repos:` workaround.

- Embedded example (`internal/schema/example.yml`) gains a comment block on the `all-repos:` section explaining that its mere presence is what enables repo iteration, and showing the empty-block pattern.
- README's Configuration section gets a paragraph saying the same thing in prose, including the `enforce --dry-run` recommendation.

Behavior is unchanged.