### PR TITLE
cli: add -v/--verbose; default to changes-only output

### DIFF
--- a/cmd/ghsecretman/main.go
+++ b/cmd/ghsecretman/main.go
@@ -87,6 +87,10 @@ commands:
 authentication:
   Reads GITHUB_TOKEN (preferred) or GH_TOKEN from the environment.
 
+output:
+  audit/apply/enforce report only changes by default. Pass -v/--verbose
+  to also see per-repo headers and unchanged ('match') entries.
+
 Run 'ghsecretman <command> -h' for command-specific flags.
 See 'ghsecretman example' for the full schema with annotations.
 `)
@@ -137,6 +141,9 @@ func runEnforce(args []string, stdout, stderr io.Writer) int {
 	repo := fs.String("repo", "", "single repo to enforce; omit to iterate every repo in the org")
 	dryRun := fs.Bool("dry-run", false, "print intended writes and deletes; make no API write calls")
 	concurrency := fs.Int("concurrency", runner.DefaultConcurrency, "max repos processed in parallel for org-wide runs")
+	var verbose bool
+	fs.BoolVar(&verbose, "verbose", false, "emit per-repo headers and `match` entries even when nothing changed")
+	fs.BoolVar(&verbose, "v", false, "verbose (shorthand)")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
@@ -157,7 +164,7 @@ func runEnforce(args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 
-	opts := runner.EnforceOptions{DryRun: *dryRun, Concurrency: *concurrency}
+	opts := runner.EnforceOptions{DryRun: *dryRun, Concurrency: *concurrency, Verbose: verbose}
 
 	if *repo != "" {
 		return runEnforceRepo(cfg, *org, *repo, backend, opts, stdout, stderr)
@@ -197,6 +204,9 @@ func runAudit(args []string, stdout, stderr io.Writer) int {
 	repo := fs.String("repo", "", "single repo to audit; omit to iterate every repo in the org")
 	showIgnored := fs.Bool("show-ignored", false, "include ignored entries in output")
 	concurrency := fs.Int("concurrency", runner.DefaultConcurrency, "max repos processed in parallel for org-wide runs")
+	var verbose bool
+	fs.BoolVar(&verbose, "verbose", false, "emit per-repo headers and `match` entries even when nothing differs")
+	fs.BoolVar(&verbose, "v", false, "verbose (shorthand)")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
@@ -218,7 +228,7 @@ func runAudit(args []string, stdout, stderr io.Writer) int {
 	}
 
 	if *repo != "" {
-		res, err := runner.AuditRepo(context.Background(), cfg, *org, *repo, backend, stdout, *showIgnored)
+		res, err := runner.AuditRepo(context.Background(), cfg, *org, *repo, backend, stdout, *showIgnored, verbose)
 		if err != nil {
 			fmt.Fprintf(stderr, "audit: %v\n", err)
 			return 1
@@ -229,7 +239,7 @@ func runAudit(args []string, stdout, stderr io.Writer) int {
 		return 0
 	}
 
-	res, err := runner.Audit(context.Background(), cfg, *org, backend, stdout, *showIgnored, runner.OrgOptions{Concurrency: *concurrency})
+	res, err := runner.Audit(context.Background(), cfg, *org, backend, stdout, *showIgnored, runner.OrgOptions{Concurrency: *concurrency, Verbose: verbose})
 	if err != nil {
 		fmt.Fprintf(stderr, "audit: %v\n", err)
 		return 1
@@ -247,6 +257,9 @@ func runApply(args []string, stdout, stderr io.Writer) int {
 	org := fs.String("org", "", "GitHub organization name")
 	repo := fs.String("repo", "", "single repo to apply; omit to iterate every repo in the org")
 	concurrency := fs.Int("concurrency", runner.DefaultConcurrency, "max repos processed in parallel for org-wide runs")
+	var verbose bool
+	fs.BoolVar(&verbose, "verbose", false, "emit per-repo headers even for repos with nothing to apply")
+	fs.BoolVar(&verbose, "v", false, "verbose (shorthand)")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
@@ -268,7 +281,7 @@ func runApply(args []string, stdout, stderr io.Writer) int {
 	}
 
 	if *repo != "" {
-		res, err := runner.ApplyRepo(context.Background(), cfg, *org, *repo, backend, stdout)
+		res, err := runner.ApplyRepo(context.Background(), cfg, *org, *repo, backend, stdout, verbose)
 		if err != nil {
 			fmt.Fprintf(stderr, "apply: %v\n", err)
 			return 1
@@ -279,7 +292,7 @@ func runApply(args []string, stdout, stderr io.Writer) int {
 		return 0
 	}
 
-	res, err := runner.Apply(context.Background(), cfg, *org, backend, stdout, runner.OrgOptions{Concurrency: *concurrency})
+	res, err := runner.Apply(context.Background(), cfg, *org, backend, stdout, runner.OrgOptions{Concurrency: *concurrency, Verbose: verbose})
 	if err != nil {
 		fmt.Fprintf(stderr, "apply: %v\n", err)
 		return 1

--- a/cmd/ghsecretman/main_test.go
+++ b/cmd/ghsecretman/main_test.go
@@ -294,7 +294,7 @@ github.com:
 	swapBackend(t, &fakeBackend{vars: map[string]string{"V": "ok"}}, nil)
 
 	var stdout, stderr bytes.Buffer
-	code := run([]string{"ghsecretman", "audit", "--config", cfgPath, "--org", "example", "--repo", "acme"}, "dev", &stdout, &stderr)
+	code := run([]string{"ghsecretman", "audit", "--config", cfgPath, "--org", "example", "--repo", "acme", "--verbose"}, "dev", &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("exit: got %d want 0; stderr=%q", code, stderr.String())
 	}
@@ -623,7 +623,7 @@ github.com:
 	swapBackend(t, be, nil)
 
 	var stdout, stderr bytes.Buffer
-	code := run([]string{"ghsecretman", "audit", "--config", cfgPath, "--org", "example"}, "dev", &stdout, &stderr)
+	code := run([]string{"ghsecretman", "audit", "--config", cfgPath, "--org", "example", "--verbose"}, "dev", &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("exit: got %d want 0; stderr=%q\nstdout=%q", code, stderr.String(), stdout.String())
 	}
@@ -765,7 +765,7 @@ github.com:
 	swapBackend(t, be, nil)
 
 	var stdout, stderr bytes.Buffer
-	code := run([]string{"ghsecretman", "audit", "--config", cfgPath, "--org", "example"}, "dev", &stdout, &stderr)
+	code := run([]string{"ghsecretman", "audit", "--config", cfgPath, "--org", "example", "--verbose"}, "dev", &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("exit: got %d want 0; stderr=%q\nstdout=%q", code, stderr.String(), stdout.String())
 	}
@@ -914,5 +914,126 @@ func TestRun_Example_ForceOverwrite(t *testing.T) {
 				t.Fatalf("file not overwritten with example: %q", data)
 			}
 		})
+	}
+}
+
+// TestRun_AuditClean_NonVerboseSilent locks in the non-verbose default:
+// when nothing differs, audit produces only a summary line (no per-repo
+// stanza, no `match` entries).
+func TestRun_AuditClean_NonVerboseSilent(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeCfg(t, dir, `
+github.com:
+  example:
+    per-repo:
+      acme:
+        managed:
+          vars:
+            V:
+              value: ok
+`)
+	swapBackend(t, &fakeBackend{vars: map[string]string{"V": "ok"}}, nil)
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"ghsecretman", "audit", "--config", cfgPath, "--org", "example", "--repo", "acme"}, "dev", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit: got %d want 0; stderr=%q", code, stderr.String())
+	}
+	if strings.Contains(stdout.String(), "repo: acme") {
+		t.Errorf("non-verbose should not emit per-repo header for clean repo: %q", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "match") {
+		t.Errorf("non-verbose should not emit match entries: %q", stdout.String())
+	}
+}
+
+// TestRun_AuditDrift_NonVerboseShowsOnlyDrift confirms that with drift
+// present, non-verbose emits the per-repo header and only the drift
+// entries (no `match` lines for the entries that were correct).
+func TestRun_AuditDrift_NonVerboseShowsOnlyDrift(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeCfg(t, dir, `
+github.com:
+  example:
+    per-repo:
+      acme:
+        managed:
+          vars:
+            OK:
+              value: same
+            DRIFT:
+              value: yaml
+`)
+	swapBackend(t, &fakeBackend{vars: map[string]string{"OK": "same", "DRIFT": "live"}}, nil)
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"ghsecretman", "audit", "--config", cfgPath, "--org", "example", "--repo", "acme"}, "dev", &stdout, &stderr)
+	if code == 0 {
+		t.Fatal("expected non-zero exit on drift")
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "repo: acme") {
+		t.Errorf("expected stanza header when drift exists: %q", out)
+	}
+	if !strings.Contains(out, "vars/DRIFT: mismatch") {
+		t.Errorf("expected DRIFT mismatch line: %q", out)
+	}
+	if strings.Contains(out, "vars/OK: match") {
+		t.Errorf("non-verbose should not emit `match` for OK: %q", out)
+	}
+}
+
+// TestRun_AuditClean_VerboseEmitsStanza is the inverse: with --verbose,
+// even a clean repo emits a header and `match` lines.
+func TestRun_AuditClean_VerboseEmitsStanza(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeCfg(t, dir, `
+github.com:
+  example:
+    per-repo:
+      acme:
+        managed:
+          vars:
+            V:
+              value: ok
+`)
+	swapBackend(t, &fakeBackend{vars: map[string]string{"V": "ok"}}, nil)
+
+	for _, flag := range []string{"-v", "--verbose"} {
+		t.Run(flag, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := run([]string{"ghsecretman", "audit", "--config", cfgPath, "--org", "example", "--repo", "acme", flag}, "dev", &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("exit: got %d want 0; stderr=%q", code, stderr.String())
+			}
+			out := stdout.String()
+			if !strings.Contains(out, "repo: acme") || !strings.Contains(out, "vars/V: match") {
+				t.Errorf("verbose should emit header and match lines: %q", out)
+			}
+		})
+	}
+}
+
+// TestRun_EnforceNoEvents_NonVerboseSilent: an enforce on a repo with no
+// managed entries and no extras produces only a summary line in
+// non-verbose mode.
+func TestRun_EnforceNoEvents_NonVerboseSilent(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeCfg(t, dir, `
+github.com:
+  example:
+    per-repo:
+      acme:
+        managed: {}
+`)
+	swapBackend(t, &fakeBackend{}, nil)
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"ghsecretman", "enforce", "--config", cfgPath, "--org", "example", "--repo", "acme"}, "dev", &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit: got %d want 0; stderr=%q", code, stderr.String())
+	}
+	if strings.Contains(stdout.String(), "repo: acme") {
+		t.Errorf("non-verbose should suppress per-repo header for no-event enforce: %q", stdout.String())
 	}
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -32,6 +32,11 @@ type OrgOptions struct {
 	// Concurrency bounds the number of repos processed in parallel. Zero
 	// or negative selects DefaultConcurrency.
 	Concurrency int
+
+	// Verbose, when true, emits per-repo headers and (in audit) match
+	// entries for every iterated repo. When false (default), repos with
+	// no events are silent and audit suppresses match entries.
+	Verbose bool
 }
 
 func resolveConcurrency(n int) int {
@@ -52,10 +57,12 @@ type Result struct {
 
 // AuditRepo runs an audit against a single repo and writes a labeled
 // stanza to out. showIgnored controls whether ignored entries appear.
+// verbose=false suppresses match entries and skips the stanza entirely
+// when no non-match drift remains.
 //
 // The repo is resolved via the per-repo > all-repos cascade. A repo with
 // no per-repo block is still valid as long as the org defines all-repos.
-func AuditRepo(ctx context.Context, cfg *config.Config, org, repo string, backend gh.Backend, out io.Writer, showIgnored bool) (Result, error) {
+func AuditRepo(ctx context.Context, cfg *config.Config, org, repo string, backend gh.Backend, out io.Writer, showIgnored, verbose bool) (Result, error) {
 	o, perRepo, err := lookupTarget(cfg, org, repo)
 	if err != nil {
 		return Result{}, err
@@ -75,7 +82,7 @@ func AuditRepo(ctx context.Context, cfg *config.Config, org, repo string, backen
 
 	effIgnored := plan.EffectiveIgnored(o.AllRepos, perRepo)
 	entries := diff.Compute(repo, intents, desiredVars, live, effIgnored)
-	writeStanza(out, org, repo, entries, showIgnored)
+	writeStanza(out, org, repo, entries, showIgnored, verbose)
 
 	return Result{Drift: diff.HasDrift(entries)}, nil
 }
@@ -123,12 +130,27 @@ func fetchLive(ctx context.Context, backend gh.Backend, org, repo string) (diff.
 	return diff.Live{Vars: vars, Secrets: secrets, Dependabot: dependabot}, nil
 }
 
-func writeStanza(out io.Writer, org, repo string, entries []diff.Entry, showIgnored bool) {
-	fmt.Fprintf(out, "org: %s\nrepo: %s\n", org, repo)
+// writeStanza writes the per-repo audit stanza. When verbose is false,
+// `match` entries are suppressed and the entire stanza (including the
+// per-repo header) is skipped if no entries remain. When verbose is true,
+// every non-ignored entry is written and the header is always printed.
+// Ignored entries are honored by showIgnored independently.
+func writeStanza(out io.Writer, org, repo string, entries []diff.Entry, showIgnored, verbose bool) {
+	visible := make([]diff.Entry, 0, len(entries))
 	for _, e := range entries {
 		if e.Status == diff.Ignored && !showIgnored {
 			continue
 		}
+		if !verbose && e.Status == diff.Match {
+			continue
+		}
+		visible = append(visible, e)
+	}
+	if len(visible) == 0 && !verbose {
+		return
+	}
+	fmt.Fprintf(out, "org: %s\nrepo: %s\n", org, repo)
+	for _, e := range visible {
 		writeEntryLine(out, e)
 	}
 }
@@ -167,10 +189,14 @@ func overrideSuffix(e diff.Entry) string {
 // "ok" or "FAILED: <err>" line is written for each managed entry; a final
 // summary line is written if any entry failed.
 //
+// When verbose is false the per-repo header is suppressed for repos with
+// nothing to apply (no managed entries). When verbose is true the header
+// is always written.
+//
 // The repo's Actions and Dependabot public keys are fetched at most once
 // per call (only when the corresponding section has at least one entry)
 // and reused across all set calls.
-func ApplyRepo(ctx context.Context, cfg *config.Config, org, repo string, backend gh.Backend, out io.Writer) (Result, error) {
+func ApplyRepo(ctx context.Context, cfg *config.Config, org, repo string, backend gh.Backend, out io.Writer, verbose bool) (Result, error) {
 	o, perRepo, err := lookupTarget(cfg, org, repo)
 	if err != nil {
 		return Result{}, err
@@ -187,7 +213,7 @@ func ApplyRepo(ctx context.Context, cfg *config.Config, org, repo string, backen
 		return Result{}, err
 	}
 
-	fmt.Fprintf(out, "org: %s\nrepo: %s\n", org, repo)
+	var body bytes.Buffer
 	res := Result{}
 	for _, in := range intents {
 		if in.Action != plan.ActionManaged {
@@ -196,10 +222,14 @@ func ApplyRepo(ctx context.Context, cfg *config.Config, org, repo string, backen
 		err := applyOne(ctx, backend, org, repo, in, resolved[entryKey(in)], actionsKey, depKey)
 		if err != nil {
 			res.Failed++
-			fmt.Fprintf(out, "  %s/%s: FAILED: %v\n", in.Kind, in.Name, err)
+			fmt.Fprintf(&body, "  %s/%s: FAILED: %v\n", in.Kind, in.Name, err)
 			continue
 		}
-		fmt.Fprintf(out, "  %s/%s: ok\n", in.Kind, in.Name)
+		fmt.Fprintf(&body, "  %s/%s: ok\n", in.Kind, in.Name)
+	}
+	if body.Len() > 0 || verbose {
+		fmt.Fprintf(out, "org: %s\nrepo: %s\n", org, repo)
+		_, _ = out.Write(body.Bytes())
 	}
 	if res.Failed > 0 {
 		fmt.Fprintf(out, "summary: %d failed\n", res.Failed)
@@ -274,12 +304,19 @@ type EnforceOptions struct {
 	// Concurrency bounds org-wide enforce iteration the same way
 	// OrgOptions.Concurrency does for Audit/Apply.
 	Concurrency int
+
+	// Verbose, when true, always emits the per-repo header even if the
+	// repo had no managed entries to set and no extras to delete. When
+	// false (default), the header is suppressed for repos with no events.
+	Verbose bool
 }
 
 // EnforceRepo applies managed values and then deletes any "extra" entries
 // — entries present on the repo but not listed in either the managed or
 // ignored block. With DryRun=true, it prints intended set/delete lines
-// without calling any write API.
+// without calling any write API. When opts.Verbose is false the per-repo
+// header is suppressed for repos with no events (no managed entries and
+// no extras).
 func EnforceRepo(ctx context.Context, cfg *config.Config, org, repo string, backend gh.Backend, out io.Writer, opts EnforceOptions) (Result, error) {
 	o, perRepo, err := lookupTarget(cfg, org, repo)
 	if err != nil {
@@ -305,10 +342,14 @@ func EnforceRepo(ctx context.Context, cfg *config.Config, org, repo string, back
 		return Result{}, err
 	}
 
-	fmt.Fprintf(out, "org: %s\nrepo: %s\n", org, repo)
+	var body bytes.Buffer
 	res := Result{}
-	res.Failed += runApplyPhase(ctx, backend, org, repo, intents, resolved, actionsKey, depKey, out, opts.DryRun)
-	res.Failed += runDeletePhase(ctx, backend, org, repo, entries, out, opts.DryRun)
+	res.Failed += runApplyPhase(ctx, backend, org, repo, intents, resolved, actionsKey, depKey, &body, opts.DryRun)
+	res.Failed += runDeletePhase(ctx, backend, org, repo, entries, &body, opts.DryRun)
+	if body.Len() > 0 || opts.Verbose {
+		fmt.Fprintf(out, "org: %s\nrepo: %s\n", org, repo)
+		_, _ = out.Write(body.Bytes())
+	}
 	if res.Failed > 0 {
 		fmt.Fprintf(out, "summary: %d failed\n", res.Failed)
 	}
@@ -495,7 +536,7 @@ func Audit(ctx context.Context, cfg *config.Config, org string, backend gh.Backe
 	}
 	res := OrgResult{}
 	if o.OrgScope != nil {
-		orgRes, err := AuditOrgScope(ctx, cfg, org, backend, out, showIgnored)
+		orgRes, err := AuditOrgScope(ctx, cfg, org, backend, out, showIgnored, opts.Verbose)
 		if err != nil {
 			fmt.Fprintf(out, "org: %s\nscope: org\n  ERROR: %v\n", org, err)
 			res.FailedRepos++
@@ -509,7 +550,7 @@ func Audit(ctx context.Context, cfg *config.Config, org string, backend gh.Backe
 	}
 	r := runOrg(ctx, repos, opts.Concurrency, out, func(repo string) repoWork {
 		return func(ctx context.Context, buf *bytes.Buffer) (Result, error) {
-			return AuditRepo(ctx, cfg, org, repo, backend, buf, showIgnored)
+			return AuditRepo(ctx, cfg, org, repo, backend, buf, showIgnored, opts.Verbose)
 		}
 	})
 	mergeOrgResult(&res, r, skipped)
@@ -537,7 +578,7 @@ func Apply(ctx context.Context, cfg *config.Config, org string, backend gh.Backe
 	}
 	res := OrgResult{}
 	if o.OrgScope != nil {
-		orgRes, err := ApplyOrgScope(ctx, cfg, org, backend, out)
+		orgRes, err := ApplyOrgScope(ctx, cfg, org, backend, out, opts.Verbose)
 		if err != nil {
 			fmt.Fprintf(out, "org: %s\nscope: org\n  ERROR: %v\n", org, err)
 			res.FailedRepos++
@@ -551,7 +592,7 @@ func Apply(ctx context.Context, cfg *config.Config, org string, backend gh.Backe
 	}
 	r := runOrg(ctx, repos, opts.Concurrency, out, func(repo string) repoWork {
 		return func(ctx context.Context, buf *bytes.Buffer) (Result, error) {
-			return ApplyRepo(ctx, cfg, org, repo, backend, buf)
+			return ApplyRepo(ctx, cfg, org, repo, backend, buf, opts.Verbose)
 		}
 	})
 	mergeOrgResult(&res, r, skipped)
@@ -595,7 +636,7 @@ func Enforce(ctx context.Context, cfg *config.Config, org string, backend gh.Bac
 // secrets defined under the org's `org:` block. It writes a single labeled
 // stanza to out. If the config has no `org:` block for orgName, the call is
 // a no-op (zero-value Result, no stanza, no error).
-func AuditOrgScope(ctx context.Context, cfg *config.Config, orgName string, backend gh.Backend, out io.Writer, showIgnored bool) (Result, error) {
+func AuditOrgScope(ctx context.Context, cfg *config.Config, orgName string, backend gh.Backend, out io.Writer, showIgnored, verbose bool) (Result, error) {
 	o, ok := cfg.Org(orgName)
 	if !ok {
 		return Result{}, fmt.Errorf("org %q not found in config", orgName)
@@ -614,7 +655,7 @@ func AuditOrgScope(ctx context.Context, cfg *config.Config, orgName string, back
 	}
 	effIgnored := plan.EffectiveOrgIgnored(o.OrgScope)
 	entries := diff.Compute("", intents, desiredVars, live, effIgnored)
-	writeOrgStanza(out, orgName, entries, showIgnored)
+	writeOrgStanza(out, orgName, entries, showIgnored, verbose)
 	return Result{Drift: diff.HasDrift(entries)}, nil
 }
 
@@ -634,12 +675,22 @@ func fetchOrgLive(ctx context.Context, backend gh.Backend, org string) (diff.Liv
 	return diff.Live{Vars: vars, Secrets: secrets, Dependabot: dependabot}, nil
 }
 
-func writeOrgStanza(out io.Writer, orgName string, entries []diff.Entry, showIgnored bool) {
-	fmt.Fprintf(out, "org: %s\nscope: org\n", orgName)
+func writeOrgStanza(out io.Writer, orgName string, entries []diff.Entry, showIgnored, verbose bool) {
+	visible := make([]diff.Entry, 0, len(entries))
 	for _, e := range entries {
 		if e.Status == diff.Ignored && !showIgnored {
 			continue
 		}
+		if !verbose && e.Status == diff.Match {
+			continue
+		}
+		visible = append(visible, e)
+	}
+	if len(visible) == 0 && !verbose {
+		return
+	}
+	fmt.Fprintf(out, "org: %s\nscope: org\n", orgName)
+	for _, e := range visible {
 		switch e.Status {
 		case diff.Mismatch:
 			fmt.Fprintf(out, "  %s/%s: mismatch (yaml=%q live=%q)\n", e.Kind, e.Name, e.DesiredValue, e.LiveValue)
@@ -651,8 +702,9 @@ func writeOrgStanza(out io.Writer, orgName string, entries []diff.Entry, showIgn
 
 // ApplyOrgScope writes org-level managed entries. It never deletes and never
 // touches anything outside the org's `org.managed` block. Returns Result with
-// per-entry write failures counted in Failed.
-func ApplyOrgScope(ctx context.Context, cfg *config.Config, orgName string, backend gh.Backend, out io.Writer) (Result, error) {
+// per-entry write failures counted in Failed. When verbose is false the
+// org-scope header is suppressed if there are no managed entries to write.
+func ApplyOrgScope(ctx context.Context, cfg *config.Config, orgName string, backend gh.Backend, out io.Writer, verbose bool) (Result, error) {
 	o, ok := cfg.Org(orgName)
 	if !ok {
 		return Result{}, fmt.Errorf("org %q not found in config", orgName)
@@ -673,7 +725,7 @@ func ApplyOrgScope(ctx context.Context, cfg *config.Config, orgName string, back
 	if err != nil {
 		return Result{}, err
 	}
-	fmt.Fprintf(out, "org: %s\nscope: org\n", orgName)
+	var body bytes.Buffer
 	res := Result{}
 	for _, in := range intents {
 		if in.Action != plan.ActionManaged {
@@ -682,10 +734,14 @@ func ApplyOrgScope(ctx context.Context, cfg *config.Config, orgName string, back
 		err := applyOrgOne(ctx, backend, orgName, in, resolved[entryKey(in)], idsByIntent[entryKey(in)], actionsKey, depKey)
 		if err != nil {
 			res.Failed++
-			fmt.Fprintf(out, "  %s/%s: FAILED: %v\n", in.Kind, in.Name, err)
+			fmt.Fprintf(&body, "  %s/%s: FAILED: %v\n", in.Kind, in.Name, err)
 			continue
 		}
-		fmt.Fprintf(out, "  %s/%s: ok\n", in.Kind, in.Name)
+		fmt.Fprintf(&body, "  %s/%s: ok\n", in.Kind, in.Name)
+	}
+	if body.Len() > 0 || verbose {
+		fmt.Fprintf(out, "org: %s\nscope: org\n", orgName)
+		_, _ = out.Write(body.Bytes())
 	}
 	if res.Failed > 0 {
 		fmt.Fprintf(out, "summary: %d failed\n", res.Failed)
@@ -800,10 +856,14 @@ func EnforceOrgScope(ctx context.Context, cfg *config.Config, orgName string, ba
 		}
 	}
 
-	fmt.Fprintf(out, "org: %s\nscope: org\n", orgName)
+	var body bytes.Buffer
 	res := Result{}
-	res.Failed += runOrgApplyPhase(ctx, backend, orgName, intents, resolved, idsByIntent, actionsKey, depKey, out, opts.DryRun)
-	res.Failed += runOrgDeletePhase(ctx, backend, orgName, entries, out, opts.DryRun)
+	res.Failed += runOrgApplyPhase(ctx, backend, orgName, intents, resolved, idsByIntent, actionsKey, depKey, &body, opts.DryRun)
+	res.Failed += runOrgDeletePhase(ctx, backend, orgName, entries, &body, opts.DryRun)
+	if body.Len() > 0 || opts.Verbose {
+		fmt.Fprintf(out, "org: %s\nscope: org\n", orgName)
+		_, _ = out.Write(body.Bytes())
+	}
 	if res.Failed > 0 {
 		fmt.Fprintf(out, "summary: %d failed\n", res.Failed)
 	}

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -352,7 +352,7 @@ github.com:
 	}
 
 	var out bytes.Buffer
-	res, err := AuditRepo(context.Background(), cfg, "example", "acme", be, &out, false)
+	res, err := AuditRepo(context.Background(), cfg, "example", "acme", be, &out, false, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -402,7 +402,7 @@ github.com:
 	}
 	be := &fakeBackend{vars: map[string]string{"V": "ok"}}
 	var out bytes.Buffer
-	res, err := AuditRepo(context.Background(), cfg, "example", "acme", be, &out, false)
+	res, err := AuditRepo(context.Background(), cfg, "example", "acme", be, &out, false, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -436,7 +436,7 @@ github.com:
 	}
 	be := &fakeBackend{vars: map[string]string{"V": "from-file"}}
 	var out bytes.Buffer
-	res, err := AuditRepo(context.Background(), cfg, "example", "acme", be, &out, false)
+	res, err := AuditRepo(context.Background(), cfg, "example", "acme", be, &out, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -448,13 +448,13 @@ github.com:
 func TestAuditRepo_UnknownOrgRepo(t *testing.T) {
 	t.Parallel()
 	cfg := &config.Config{Orgs: map[string]*config.Org{}}
-	_, err := AuditRepo(context.Background(), cfg, "missing", "acme", &fakeBackend{}, &bytes.Buffer{}, false)
+	_, err := AuditRepo(context.Background(), cfg, "missing", "acme", &fakeBackend{}, &bytes.Buffer{}, false, true)
 	if err == nil {
 		t.Fatal("expected error for unknown org")
 	}
 
 	cfg.Orgs["example"] = &config.Org{PerRepo: map[string]*config.Repo{}}
-	_, err = AuditRepo(context.Background(), cfg, "example", "missing-repo", &fakeBackend{}, &bytes.Buffer{}, false)
+	_, err = AuditRepo(context.Background(), cfg, "example", "missing-repo", &fakeBackend{}, &bytes.Buffer{}, false, true)
 	if err == nil {
 		t.Fatal("expected error for unknown repo")
 	}
@@ -468,7 +468,7 @@ func TestAuditRepo_BackendError(t *testing.T) {
 		},
 	}
 	be := &fakeBackend{err: errors.New("boom")}
-	_, err := AuditRepo(context.Background(), cfg, "example", "acme", be, &bytes.Buffer{}, false)
+	_, err := AuditRepo(context.Background(), cfg, "example", "acme", be, &bytes.Buffer{}, false, true)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -495,7 +495,7 @@ github.com:
 		t.Fatal(err)
 	}
 	be := &fakeBackend{vars: map[string]string{"V": "x"}}
-	_, err = AuditRepo(context.Background(), cfg, "example", "acme", be, &bytes.Buffer{}, false)
+	_, err = AuditRepo(context.Background(), cfg, "example", "acme", be, &bytes.Buffer{}, false, true)
 	if err == nil {
 		t.Fatal("expected error for missing file")
 	}
@@ -539,7 +539,7 @@ github.com:
 	}
 	be := &fakeBackend{}
 	var out bytes.Buffer
-	res, err := ApplyRepo(context.Background(), cfg, "example", "acme", be, &out)
+	res, err := ApplyRepo(context.Background(), cfg, "example", "acme", be, &out, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -622,7 +622,7 @@ github.com:
 		t.Fatal(err)
 	}
 	be := &fakeBackend{}
-	if _, err := ApplyRepo(context.Background(), cfg, "example", "acme", be, &bytes.Buffer{}); err != nil {
+	if _, err := ApplyRepo(context.Background(), cfg, "example", "acme", be, &bytes.Buffer{}, true); err != nil {
 		t.Fatal(err)
 	}
 	if be.actionsKeyFetches != 0 || be.dependabotKeyFetches != 0 {
@@ -660,7 +660,7 @@ github.com:
 		setErr: map[string]error{"vars/V_BAD": errors.New("rate limit")},
 	}
 	var out bytes.Buffer
-	res, err := ApplyRepo(context.Background(), cfg, "example", "acme", be, &out)
+	res, err := ApplyRepo(context.Background(), cfg, "example", "acme", be, &out, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -703,7 +703,7 @@ github.com:
 		t.Fatal(err)
 	}
 	be := &fakeBackend{actionsKeyErr: errors.New("forbidden")}
-	if _, err := ApplyRepo(context.Background(), cfg, "example", "acme", be, &bytes.Buffer{}); err == nil {
+	if _, err := ApplyRepo(context.Background(), cfg, "example", "acme", be, &bytes.Buffer{}, true); err == nil {
 		t.Fatal("expected error when public key fetch fails")
 	}
 }
@@ -729,7 +729,7 @@ github.com:
 		t.Fatal(err)
 	}
 	be := &fakeBackend{dependabotKeyErr: errors.New("forbidden")}
-	if _, err := ApplyRepo(context.Background(), cfg, "example", "acme", be, &bytes.Buffer{}); err == nil {
+	if _, err := ApplyRepo(context.Background(), cfg, "example", "acme", be, &bytes.Buffer{}, true); err == nil {
 		t.Fatal("expected error when dependabot public key fetch fails")
 	}
 }
@@ -754,7 +754,7 @@ github.com:
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := ApplyRepo(context.Background(), cfg, "example", "acme", &fakeBackend{}, &bytes.Buffer{}); err == nil {
+	if _, err := ApplyRepo(context.Background(), cfg, "example", "acme", &fakeBackend{}, &bytes.Buffer{}, true); err == nil {
 		t.Fatal("expected resolve error")
 	}
 }
@@ -762,11 +762,11 @@ github.com:
 func TestApplyRepo_UnknownOrgRepo(t *testing.T) {
 	t.Parallel()
 	cfg := &config.Config{Orgs: map[string]*config.Org{}}
-	if _, err := ApplyRepo(context.Background(), cfg, "missing", "acme", &fakeBackend{}, &bytes.Buffer{}); err == nil {
+	if _, err := ApplyRepo(context.Background(), cfg, "missing", "acme", &fakeBackend{}, &bytes.Buffer{}, true); err == nil {
 		t.Fatal("expected error for unknown org")
 	}
 	cfg.Orgs["example"] = &config.Org{PerRepo: map[string]*config.Repo{}}
-	if _, err := ApplyRepo(context.Background(), cfg, "example", "missing", &fakeBackend{}, &bytes.Buffer{}); err == nil {
+	if _, err := ApplyRepo(context.Background(), cfg, "example", "missing", &fakeBackend{}, &bytes.Buffer{}, true); err == nil {
 		t.Fatal("expected error for unknown repo")
 	}
 }
@@ -836,7 +836,7 @@ github.com:
 
 	be := &fakeBackend{}
 	var out bytes.Buffer
-	res, err := ApplyRepo(context.Background(), cfg, "example", "acme", be, &out)
+	res, err := ApplyRepo(context.Background(), cfg, "example", "acme", be, &out, true)
 	if err != nil {
 		t.Fatalf("targeting acme should not require env vars referenced only by another repo, got: %v", err)
 	}
@@ -868,7 +868,7 @@ github.com:
 		t.Fatal(err)
 	}
 
-	_, err = ApplyRepo(context.Background(), cfg, "example", "acme", &fakeBackend{}, &bytes.Buffer{})
+	_, err = ApplyRepo(context.Background(), cfg, "example", "acme", &fakeBackend{}, &bytes.Buffer{}, true)
 	if err == nil {
 		t.Fatal("expected error when a targeted entry's env var is unset")
 	}
@@ -903,7 +903,7 @@ github.com:
 
 	be := &fakeBackend{vars: map[string]string{"V": "live-side"}}
 	var out bytes.Buffer
-	res, err := AuditRepo(context.Background(), cfg, "example", "acme", be, &out, false)
+	res, err := AuditRepo(context.Background(), cfg, "example", "acme", be, &out, false, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -951,7 +951,7 @@ github.com:
 	}
 	be := &fakeBackend{}
 	var out bytes.Buffer
-	res, err := ApplyRepo(context.Background(), cfg, "example", "acme", be, &out)
+	res, err := ApplyRepo(context.Background(), cfg, "example", "acme", be, &out, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1013,7 +1013,7 @@ github.com:
 		dependabot: []string{"D_KEEP", "D_EXTRA"},
 	}
 	var out bytes.Buffer
-	res, err := EnforceRepo(context.Background(), cfg, "example", "acme", be, &out, EnforceOptions{})
+	res, err := EnforceRepo(context.Background(), cfg, "example", "acme", be, &out, EnforceOptions{Verbose: true})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1086,7 +1086,7 @@ github.com:
 		dependabot: []string{"D_LEAVE_ALONE"},
 	}
 	var out bytes.Buffer
-	if _, err := EnforceRepo(context.Background(), cfg, "example", "acme", be, &out, EnforceOptions{}); err != nil {
+	if _, err := EnforceRepo(context.Background(), cfg, "example", "acme", be, &out, EnforceOptions{Verbose: true}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	for _, n := range be.delVarCalls {
@@ -1149,7 +1149,7 @@ github.com:
 		secrets: []string{"S_EXTRA"},
 	}
 	var out bytes.Buffer
-	res, err := EnforceRepo(context.Background(), cfg, "example", "acme", be, &out, EnforceOptions{DryRun: true})
+	res, err := EnforceRepo(context.Background(), cfg, "example", "acme", be, &out, EnforceOptions{DryRun: true, Verbose: true})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1202,7 +1202,7 @@ github.com:
 		t.Fatal(err)
 	}
 	be := &fakeBackend{}
-	if _, err := EnforceRepo(context.Background(), cfg, "example", "acme", be, &bytes.Buffer{}, EnforceOptions{DryRun: true}); err != nil {
+	if _, err := EnforceRepo(context.Background(), cfg, "example", "acme", be, &bytes.Buffer{}, EnforceOptions{DryRun: true, Verbose: true}); err != nil {
 		t.Fatalf("dry-run should not require value resolution; got: %v", err)
 	}
 }
@@ -1229,7 +1229,7 @@ github.com:
 		delErr: map[string]error{"vars/V_BAD": errors.New("boom")},
 	}
 	var out bytes.Buffer
-	res, err := EnforceRepo(context.Background(), cfg, "example", "acme", be, &out, EnforceOptions{})
+	res, err := EnforceRepo(context.Background(), cfg, "example", "acme", be, &out, EnforceOptions{Verbose: true})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1251,11 +1251,11 @@ github.com:
 func TestEnforceRepo_UnknownOrgRepo(t *testing.T) {
 	t.Parallel()
 	cfg := &config.Config{Orgs: map[string]*config.Org{}}
-	if _, err := EnforceRepo(context.Background(), cfg, "missing", "acme", &fakeBackend{}, &bytes.Buffer{}, EnforceOptions{}); err == nil {
+	if _, err := EnforceRepo(context.Background(), cfg, "missing", "acme", &fakeBackend{}, &bytes.Buffer{}, EnforceOptions{Verbose: true}); err == nil {
 		t.Fatal("expected error for unknown org")
 	}
 	cfg.Orgs["example"] = &config.Org{PerRepo: map[string]*config.Repo{}}
-	if _, err := EnforceRepo(context.Background(), cfg, "example", "missing", &fakeBackend{}, &bytes.Buffer{}, EnforceOptions{}); err == nil {
+	if _, err := EnforceRepo(context.Background(), cfg, "example", "missing", &fakeBackend{}, &bytes.Buffer{}, EnforceOptions{Verbose: true}); err == nil {
 		t.Fatal("expected error for unknown repo")
 	}
 }
@@ -1268,7 +1268,7 @@ func TestEnforceRepo_BackendListError(t *testing.T) {
 		},
 	}
 	be := &fakeBackend{err: errors.New("boom")}
-	if _, err := EnforceRepo(context.Background(), cfg, "example", "acme", be, &bytes.Buffer{}, EnforceOptions{}); err == nil {
+	if _, err := EnforceRepo(context.Background(), cfg, "example", "acme", be, &bytes.Buffer{}, EnforceOptions{Verbose: true}); err == nil {
 		t.Fatal("expected error")
 	}
 }
@@ -1293,7 +1293,7 @@ github.com:
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := EnforceRepo(context.Background(), cfg, "example", "acme", &fakeBackend{}, &bytes.Buffer{}, EnforceOptions{}); err == nil {
+	if _, err := EnforceRepo(context.Background(), cfg, "example", "acme", &fakeBackend{}, &bytes.Buffer{}, EnforceOptions{Verbose: true}); err == nil {
 		t.Fatal("expected resolve error in live enforce mode")
 	}
 }
@@ -1322,7 +1322,7 @@ github.com:
 		vars:     map[string]string{"ALL_VAR": "ok"},
 	}
 	var out bytes.Buffer
-	res, err := Audit(context.Background(), cfg, "example", be, &out, false, OrgOptions{})
+	res, err := Audit(context.Background(), cfg, "example", be, &out, false, OrgOptions{Verbose: true})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1366,7 +1366,7 @@ github.com:
 		vars:     map[string]string{"V": "ok"},
 	}
 	var out bytes.Buffer
-	res, err := Audit(context.Background(), cfg, "example", be, &out, false, OrgOptions{})
+	res, err := Audit(context.Background(), cfg, "example", be, &out, false, OrgOptions{Verbose: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1403,7 +1403,7 @@ github.com:
 		err:      errors.New("boom"),
 	}
 	var out bytes.Buffer
-	res, err := Audit(context.Background(), cfg, "example", be, &out, false, OrgOptions{})
+	res, err := Audit(context.Background(), cfg, "example", be, &out, false, OrgOptions{Verbose: true})
 	if err != nil {
 		t.Fatalf("Audit should continue on per-repo error, not return one: %v", err)
 	}
@@ -1436,7 +1436,7 @@ github.com:
 		t.Fatal(err)
 	}
 	be := &fakeBackend{orgReposErr: errors.New("forbidden")}
-	if _, err := Audit(context.Background(), cfg, "example", be, &bytes.Buffer{}, false, OrgOptions{}); err == nil {
+	if _, err := Audit(context.Background(), cfg, "example", be, &bytes.Buffer{}, false, OrgOptions{Verbose: true}); err == nil {
 		t.Fatal("expected error when ListOrgRepos fails")
 	}
 }
@@ -1444,7 +1444,7 @@ github.com:
 func TestAudit_UnknownOrg(t *testing.T) {
 	t.Parallel()
 	cfg := &config.Config{Orgs: map[string]*config.Org{}}
-	if _, err := Audit(context.Background(), cfg, "missing", &fakeBackend{}, &bytes.Buffer{}, false, OrgOptions{}); err == nil {
+	if _, err := Audit(context.Background(), cfg, "missing", &fakeBackend{}, &bytes.Buffer{}, false, OrgOptions{Verbose: true}); err == nil {
 		t.Fatal("expected error for unknown org")
 	}
 }
@@ -1476,7 +1476,7 @@ github.com:
 	}
 	be := &fakeBackend{orgRepos: []string{"acme", "beta"}}
 	var out bytes.Buffer
-	res, err := Apply(context.Background(), cfg, "example", be, &out, OrgOptions{})
+	res, err := Apply(context.Background(), cfg, "example", be, &out, OrgOptions{Verbose: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1501,7 +1501,7 @@ github.com:
 func TestApply_UnknownOrg(t *testing.T) {
 	t.Parallel()
 	cfg := &config.Config{Orgs: map[string]*config.Org{}}
-	if _, err := Apply(context.Background(), cfg, "missing", &fakeBackend{}, &bytes.Buffer{}, OrgOptions{}); err == nil {
+	if _, err := Apply(context.Background(), cfg, "missing", &fakeBackend{}, &bytes.Buffer{}, OrgOptions{Verbose: true}); err == nil {
 		t.Fatal("expected error")
 	}
 }
@@ -1512,7 +1512,7 @@ func TestApply_ListOrgReposError(t *testing.T) {
 		"example": {AllRepos: &config.Repo{}},
 	}}
 	be := &fakeBackend{orgReposErr: errors.New("boom")}
-	if _, err := Apply(context.Background(), cfg, "example", be, &bytes.Buffer{}, OrgOptions{}); err == nil {
+	if _, err := Apply(context.Background(), cfg, "example", be, &bytes.Buffer{}, OrgOptions{Verbose: true}); err == nil {
 		t.Fatal("expected error")
 	}
 }
@@ -1541,7 +1541,7 @@ github.com:
 		vars:     map[string]string{"EXTRA": "x"},
 	}
 	var out bytes.Buffer
-	if _, err := Enforce(context.Background(), cfg, "example", be, &out, EnforceOptions{DryRun: true}); err != nil {
+	if _, err := Enforce(context.Background(), cfg, "example", be, &out, EnforceOptions{DryRun: true, Verbose: true}); err != nil {
 		t.Fatal(err)
 	}
 	if len(be.setVarCalls)+len(be.delVarCalls) != 0 {
@@ -1558,7 +1558,7 @@ github.com:
 func TestEnforce_UnknownOrg(t *testing.T) {
 	t.Parallel()
 	cfg := &config.Config{Orgs: map[string]*config.Org{}}
-	if _, err := Enforce(context.Background(), cfg, "missing", &fakeBackend{}, &bytes.Buffer{}, EnforceOptions{}); err == nil {
+	if _, err := Enforce(context.Background(), cfg, "missing", &fakeBackend{}, &bytes.Buffer{}, EnforceOptions{Verbose: true}); err == nil {
 		t.Fatal("expected error")
 	}
 }
@@ -1569,7 +1569,7 @@ func TestEnforce_ListOrgReposError(t *testing.T) {
 		"example": {AllRepos: &config.Repo{}},
 	}}
 	be := &fakeBackend{orgReposErr: errors.New("boom")}
-	if _, err := Enforce(context.Background(), cfg, "example", be, &bytes.Buffer{}, EnforceOptions{}); err == nil {
+	if _, err := Enforce(context.Background(), cfg, "example", be, &bytes.Buffer{}, EnforceOptions{Verbose: true}); err == nil {
 		t.Fatal("expected error")
 	}
 }
@@ -1597,7 +1597,7 @@ github.com:
 		t.Fatal(err)
 	}
 	be := &fakeBackend{vars: map[string]string{"V": "shared"}}
-	res, err := AuditRepo(context.Background(), cfg, "example", "any-repo", be, &bytes.Buffer{}, false)
+	res, err := AuditRepo(context.Background(), cfg, "example", "any-repo", be, &bytes.Buffer{}, false, true)
 	if err != nil {
 		t.Fatalf("repo with no per-repo entry should still audit when all-repos exists: %v", err)
 	}
@@ -1634,7 +1634,7 @@ github.com:
 		t.Fatal(err)
 	}
 	be := &fakeBackend{}
-	if _, err := ApplyRepo(context.Background(), cfg, "example", "acme", be, &bytes.Buffer{}); err != nil {
+	if _, err := ApplyRepo(context.Background(), cfg, "example", "acme", be, &bytes.Buffer{}, true); err != nil {
 		t.Fatal(err)
 	}
 	if len(be.setVarCalls) != 1 || be.setVarCalls[0].value != "acme-only" {
@@ -1669,7 +1669,7 @@ github.com:
 		t.Fatal(err)
 	}
 	be := &fakeBackend{}
-	if _, err := ApplyRepo(context.Background(), cfg, "example", "acme", be, &bytes.Buffer{}); err != nil {
+	if _, err := ApplyRepo(context.Background(), cfg, "example", "acme", be, &bytes.Buffer{}, true); err != nil {
 		t.Fatal(err)
 	}
 	if len(be.setVarCalls) != 0 {
@@ -1705,7 +1705,7 @@ github.com:
 		t.Fatal(err)
 	}
 	be := &fakeBackend{}
-	if _, err := ApplyRepo(context.Background(), cfg, "example", "acme", be, &bytes.Buffer{}); err != nil {
+	if _, err := ApplyRepo(context.Background(), cfg, "example", "acme", be, &bytes.Buffer{}, true); err != nil {
 		t.Fatal(err)
 	}
 	if len(be.setVarCalls) != 1 || be.setVarCalls[0].value != "acme-explicit" {
@@ -1734,7 +1734,7 @@ github.com:
 	}
 	be := &fakeBackend{vars: map[string]string{"IG_VAR": "x"}}
 	var out bytes.Buffer
-	res, err := AuditRepo(context.Background(), cfg, "example", "acme", be, &out, true)
+	res, err := AuditRepo(context.Background(), cfg, "example", "acme", be, &out, true, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1781,7 +1781,7 @@ github.com:
 	}
 	be := &fakeBackend{vars: map[string]string{"V_MATCH": "acme-match"}}
 	var out bytes.Buffer
-	if _, err := AuditRepo(context.Background(), cfg, "example", "acme", be, &out, false); err != nil {
+	if _, err := AuditRepo(context.Background(), cfg, "example", "acme", be, &out, false, true); err != nil {
 		t.Fatal(err)
 	}
 	s := out.String()
@@ -1829,7 +1829,7 @@ github.com:
 	// an all-repos.managed entry.
 	be := &fakeBackend{}
 	var quiet bytes.Buffer
-	if _, err := AuditRepo(context.Background(), cfg, "example", "acme", be, &quiet, false); err != nil {
+	if _, err := AuditRepo(context.Background(), cfg, "example", "acme", be, &quiet, false, true); err != nil {
 		t.Fatal(err)
 	}
 	if strings.Contains(quiet.String(), "V_SHIELD") {
@@ -1838,7 +1838,7 @@ github.com:
 
 	// With --show-ignored: an "override (ignored)" row that names both layers.
 	var loud bytes.Buffer
-	if _, err := AuditRepo(context.Background(), cfg, "example", "acme", be, &loud, true); err != nil {
+	if _, err := AuditRepo(context.Background(), cfg, "example", "acme", be, &loud, true, true); err != nil {
 		t.Fatal(err)
 	}
 	for _, want := range []string{
@@ -1913,7 +1913,7 @@ github.com:
 
 	var out bytes.Buffer
 	limit := 4
-	if _, err := Audit(context.Background(), cfg, "example", be, &out, false, OrgOptions{Concurrency: limit}); err != nil {
+	if _, err := Audit(context.Background(), cfg, "example", be, &out, false, OrgOptions{Concurrency: limit, Verbose: true}); err != nil {
 		t.Fatal(err)
 	}
 	if got := int(be.maxInFlight.Load()); got > limit {
@@ -1959,7 +1959,7 @@ github.com:
 	}
 
 	var out bytes.Buffer
-	if _, err := Audit(context.Background(), cfg, "example", be, &out, false, OrgOptions{Concurrency: 8}); err != nil {
+	if _, err := Audit(context.Background(), cfg, "example", be, &out, false, OrgOptions{Concurrency: 8, Verbose: true}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2027,7 +2027,7 @@ github.com:
 		vars:     map[string]string{"V": "ok"},
 	}
 	var out bytes.Buffer
-	res, err := Audit(context.Background(), cfg, "example", be, &out, false, OrgOptions{})
+	res, err := Audit(context.Background(), cfg, "example", be, &out, false, OrgOptions{Verbose: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2110,7 +2110,7 @@ github.com:
 				vars:     tc.live,
 				err:      tc.listErr,
 			}
-			res, err := Audit(context.Background(), cfg, "example", be, &bytes.Buffer{}, false, OrgOptions{})
+			res, err := Audit(context.Background(), cfg, "example", be, &bytes.Buffer{}, false, OrgOptions{Verbose: true})
 			if err != nil {
 				t.Fatalf("Audit returned err: %v", err)
 			}
@@ -2155,7 +2155,7 @@ github.com:
 		setErr:   map[string]error{"vars/V": errors.New("rate limit")},
 	}
 	var out bytes.Buffer
-	res, err := Apply(context.Background(), cfg, "example", be, &out, OrgOptions{Concurrency: 3})
+	res, err := Apply(context.Background(), cfg, "example", be, &out, OrgOptions{Concurrency: 3, Verbose: true})
 	if err != nil {
 		t.Fatalf("apply should not return an error on per-entry failures: %v", err)
 	}
@@ -2184,7 +2184,7 @@ github.com:
 `)
 	be := &fakeBackend{}
 	var out bytes.Buffer
-	res, err := AuditOrgScope(context.Background(), cfg, "example", be, &out, false)
+	res, err := AuditOrgScope(context.Background(), cfg, "example", be, &out, false, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -2219,7 +2219,7 @@ github.com:
 		orgDependabot: []string{},
 	}
 	var out bytes.Buffer
-	res, err := AuditOrgScope(context.Background(), cfg, "example", be, &out, false)
+	res, err := AuditOrgScope(context.Background(), cfg, "example", be, &out, false, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -2245,7 +2245,7 @@ func TestAuditOrgScope_UnknownOrg(t *testing.T) {
 	t.Parallel()
 	cfg := mustLoadCfg(t, `github.com: {}`)
 	be := &fakeBackend{}
-	if _, err := AuditOrgScope(context.Background(), cfg, "ghost", be, &bytes.Buffer{}, false); err == nil {
+	if _, err := AuditOrgScope(context.Background(), cfg, "ghost", be, &bytes.Buffer{}, false, true); err == nil {
 		t.Fatal("expected error")
 	}
 }
@@ -2262,7 +2262,7 @@ github.com:
             value: x
 `)
 	be := &fakeBackend{err: errors.New("boom")}
-	if _, err := AuditOrgScope(context.Background(), cfg, "example", be, &bytes.Buffer{}, false); err == nil {
+	if _, err := AuditOrgScope(context.Background(), cfg, "example", be, &bytes.Buffer{}, false, true); err == nil {
 		t.Fatal("expected error")
 	}
 }
@@ -2295,7 +2295,7 @@ github.com:
 		repoIDs: map[string]int64{"alpha": 1, "beta": 2},
 	}
 	var out bytes.Buffer
-	res, err := ApplyOrgScope(context.Background(), cfg, "example", be, &out)
+	res, err := ApplyOrgScope(context.Background(), cfg, "example", be, &out, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -2349,7 +2349,7 @@ github.com:
             value: x
 `)
 	be := &fakeBackend{}
-	if _, err := ApplyOrgScope(context.Background(), cfg, "example", be, &bytes.Buffer{}); err != nil {
+	if _, err := ApplyOrgScope(context.Background(), cfg, "example", be, &bytes.Buffer{}, true); err != nil {
 		t.Fatal(err)
 	}
 	if be.orgActionsKeyFetches != 0 || be.orgDependabotKeyFetches != 0 {
@@ -2373,7 +2373,7 @@ github.com:
               - missing
 `)
 	be := &fakeBackend{repoIDs: map[string]int64{}}
-	if _, err := ApplyOrgScope(context.Background(), cfg, "example", be, &bytes.Buffer{}); err == nil {
+	if _, err := ApplyOrgScope(context.Background(), cfg, "example", be, &bytes.Buffer{}, true); err == nil {
 		t.Fatal("expected error from repo id lookup")
 	}
 }
@@ -2395,7 +2395,7 @@ github.com:
 		setErr: map[string]error{"org/vars/V_BAD": errors.New("boom")},
 	}
 	var out bytes.Buffer
-	res, err := ApplyOrgScope(context.Background(), cfg, "example", be, &out)
+	res, err := ApplyOrgScope(context.Background(), cfg, "example", be, &out, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2412,7 +2412,7 @@ func TestApplyOrgScope_NoOrgBlockIsNoop(t *testing.T) {
 	cfg := mustLoadCfg(t, `github.com: {example: {}}`)
 	be := &fakeBackend{}
 	var out bytes.Buffer
-	if _, err := ApplyOrgScope(context.Background(), cfg, "example", be, &out); err != nil {
+	if _, err := ApplyOrgScope(context.Background(), cfg, "example", be, &out, true); err != nil {
 		t.Fatal(err)
 	}
 	if out.Len() != 0 {
@@ -2423,7 +2423,7 @@ func TestApplyOrgScope_NoOrgBlockIsNoop(t *testing.T) {
 func TestApplyOrgScope_UnknownOrg(t *testing.T) {
 	t.Parallel()
 	cfg := mustLoadCfg(t, `github.com: {}`)
-	if _, err := ApplyOrgScope(context.Background(), cfg, "ghost", &fakeBackend{}, &bytes.Buffer{}); err == nil {
+	if _, err := ApplyOrgScope(context.Background(), cfg, "ghost", &fakeBackend{}, &bytes.Buffer{}, true); err == nil {
 		t.Fatal("expected error")
 	}
 }
@@ -2446,7 +2446,7 @@ github.com:
 		orgVars: map[string]string{"KEEP": "k", "EXTRA": "drop", "LEAVE": "alone"},
 	}
 	var out bytes.Buffer
-	res, err := EnforceOrgScope(context.Background(), cfg, "example", be, &out, EnforceOptions{})
+	res, err := EnforceOrgScope(context.Background(), cfg, "example", be, &out, EnforceOptions{Verbose: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2477,7 +2477,7 @@ github.com:
 `)
 	be := &fakeBackend{orgVars: map[string]string{"EXTRA": "y"}}
 	var out bytes.Buffer
-	if _, err := EnforceOrgScope(context.Background(), cfg, "example", be, &out, EnforceOptions{DryRun: true}); err != nil {
+	if _, err := EnforceOrgScope(context.Background(), cfg, "example", be, &out, EnforceOptions{DryRun: true, Verbose: true}); err != nil {
 		t.Fatal(err)
 	}
 	if len(be.setOrgVarCalls) != 0 || len(be.delOrgVarCalls) != 0 {
@@ -2494,7 +2494,7 @@ func TestEnforceOrgScope_NoOrgBlock(t *testing.T) {
 	cfg := mustLoadCfg(t, `github.com: {example: {}}`)
 	be := &fakeBackend{}
 	var out bytes.Buffer
-	if _, err := EnforceOrgScope(context.Background(), cfg, "example", be, &out, EnforceOptions{}); err != nil {
+	if _, err := EnforceOrgScope(context.Background(), cfg, "example", be, &out, EnforceOptions{Verbose: true}); err != nil {
 		t.Fatal(err)
 	}
 	if out.Len() != 0 {
@@ -2505,7 +2505,7 @@ func TestEnforceOrgScope_NoOrgBlock(t *testing.T) {
 func TestEnforceOrgScope_UnknownOrg(t *testing.T) {
 	t.Parallel()
 	cfg := mustLoadCfg(t, `github.com: {}`)
-	if _, err := EnforceOrgScope(context.Background(), cfg, "ghost", &fakeBackend{}, &bytes.Buffer{}, EnforceOptions{}); err == nil {
+	if _, err := EnforceOrgScope(context.Background(), cfg, "ghost", &fakeBackend{}, &bytes.Buffer{}, EnforceOptions{Verbose: true}); err == nil {
 		t.Fatal("expected error")
 	}
 }
@@ -2533,7 +2533,7 @@ github.com:
 		orgVars:  map[string]string{"ORG_VAR": "x"},
 	}
 	var out bytes.Buffer
-	res, err := Audit(context.Background(), cfg, "example", be, &out, false, OrgOptions{Concurrency: 1})
+	res, err := Audit(context.Background(), cfg, "example", be, &out, false, OrgOptions{Concurrency: 1, Verbose: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2568,7 +2568,7 @@ github.com:
 `)
 	be := &fakeBackend{orgRepos: []string{"acme"}}
 	var out bytes.Buffer
-	if _, err := Apply(context.Background(), cfg, "example", be, &out, OrgOptions{Concurrency: 1}); err != nil {
+	if _, err := Apply(context.Background(), cfg, "example", be, &out, OrgOptions{Concurrency: 1, Verbose: true}); err != nil {
 		t.Fatal(err)
 	}
 	if len(be.setOrgVarCalls) != 1 || be.setOrgVarCalls[0].name != "ORG_VAR" {


### PR DESCRIPTION
Audit/apply/enforce produced one stanza per iterated repo with every managed entry's status, including \`match\` lines. With many repos that output drowned out the changes you actually cared about. Flip the defaults so only events are shown.

## Default (non-verbose)

- **Audit** — per-repo header and entries are written only when the repo has drift. \`match\` entries are suppressed; mismatch / missing / extra are shown. Org scope follows the same rule.
- **Apply** — per-repo header is suppressed for repos with no managed entries. Repos with managed entries still emit every \`set ok\`/\`FAILED\` line — those are the changes.
- **Enforce** — per-repo header is suppressed for repos with no events (no managed entries, no extras, no failures). Set / delete / dry-run lines remain unchanged.

## New flag

\`-v\` / \`--verbose\` on each of \`audit\`, \`apply\`, \`enforce\` restores the prior verbose output (per-repo headers and \`match\` entries everywhere).

## Implementation

- \`internal/runner\`: \`writeStanza\` / \`writeOrgStanza\` filter \`match\` when \`!verbose\` and skip empty stanzas; \`ApplyRepo\` / \`EnforceRepo\` / \`ApplyOrgScope\` / \`EnforceOrgScope\` buffer body output and only emit the header when the body is non-empty (or verbose is set). \`OrgOptions\` and \`EnforceOptions\` gain a \`Verbose\` field.
- \`cmd/ghsecretman\`: each subcommand parses \`--verbose\` / \`-v\` and forwards it. Top-level help mentions the new flag.

## Tests

- Existing assertions on stanza output now run with \`verbose=true\` to keep their prior expectations.
- New tests lock in the non-verbose default: clean repo emits no stanza, drift emits only the drift line, no-event enforce is silent, verbose restores the old output.

Net diff: +298 / -104.